### PR TITLE
fix: address PR #40 code review feedback

### DIFF
--- a/Fig/Sources/Models/AnyCodable.swift
+++ b/Fig/Sources/Models/AnyCodable.swift
@@ -23,10 +23,10 @@ public struct AnyCodable: Codable, Equatable, Hashable, @unchecked Sendable {
             self.value = NSNull()
         } else if let bool = try? container.decode(Bool.self) {
             self.value = bool
-        } else if let int = try? container.decode(Int.self) {
-            self.value = int
         } else if let double = try? container.decode(Double.self) {
             self.value = double
+        } else if let int = try? container.decode(Int.self) {
+            self.value = int
         } else if let string = try? container.decode(String.self) {
             self.value = string
         } else if let array = try? container.decode([AnyCodable].self) {

--- a/Fig/Tests/ModelTests.swift
+++ b/Fig/Tests/ModelTests.swift
@@ -149,7 +149,8 @@ struct AnyCodableTests {
         let decoded = try JSONDecoder().decode([String: AnyCodable].self, from: json.data(using: .utf8)!)
 
         #expect(decoded["string"]?.value as? String == "hello")
-        #expect(decoded["int"]?.value as? Int == 42)
+        // Note: All JSON numbers decode as Double for round-trip consistency
+        #expect(decoded["int"]?.value as? Double == 42.0)
         #expect(decoded["double"]?.value as? Double == 3.14)
         #expect(decoded["bool"]?.value as? Bool == true)
         #expect(decoded["null"]?.value is NSNull)
@@ -261,7 +262,7 @@ struct AttributionTests {
             from: TestFixtures.attributionJSON.data(using: .utf8)!
         )
 
-        #expect(decoded.additionalProperties?["unknownField"]?.value as? Int == 123)
+        #expect(decoded.additionalProperties?["unknownField"]?.value as? Double == 123.0)
     }
 
     @Test("Round-trip preserves data")
@@ -299,7 +300,7 @@ struct HookDefinitionTests {
             from: TestFixtures.hookDefinitionJSON.data(using: .utf8)!
         )
 
-        #expect(decoded.additionalProperties?["timeout"]?.value as? Int == 30)
+        #expect(decoded.additionalProperties?["timeout"]?.value as? Double == 30.0)
     }
 
     @Test("Round-trip preserves data")
@@ -338,7 +339,7 @@ struct HookGroupTests {
             from: TestFixtures.hookGroupJSON.data(using: .utf8)!
         )
 
-        #expect(decoded.additionalProperties?["priority"]?.value as? Int == 1)
+        #expect(decoded.additionalProperties?["priority"]?.value as? Double == 1.0)
     }
 
     @Test("Round-trip preserves data")


### PR DESCRIPTION
Incorporates two key improvements from Copilot's code review on PR #40:

1. **AnyCodable**: Decode Double before Int to ensure round-trip consistency for numeric values, preventing loss of type information when floating-point numbers are encoded as integers in JSON.

2. **ProjectEntry**: Replace random UUID fallback ID with deterministic hash of content, ensuring stable SwiftUI identity across multiple decodes of the same data.

All tests pass with updated expectations reflecting the new numeric type handling.