### PR TITLE
feat: implement epic:project-explorer

### DIFF
--- a/Fig/Sources/Models/NavigationSelection.swift
+++ b/Fig/Sources/Models/NavigationSelection.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Represents the current selection in the sidebar navigation.
+enum NavigationSelection: Hashable, Sendable {
+    /// Global settings view (~/.claude/settings.json).
+    case globalSettings
+
+    /// A specific project selected by its path.
+    case project(String)
+
+    // MARK: Internal
+
+    /// Returns the project path if this is a project selection.
+    var projectPath: String? {
+        if case let .project(path) = self {
+            return path
+        }
+        return nil
+    }
+
+    /// Whether this selection is for global settings.
+    var isGlobalSettings: Bool {
+        if case .globalSettings = self {
+            return true
+        }
+        return false
+    }
+}

--- a/Fig/Sources/ViewModels/ProjectDetailViewModel.swift
+++ b/Fig/Sources/ViewModels/ProjectDetailViewModel.swift
@@ -1,0 +1,376 @@
+import AppKit
+import Foundation
+import OSLog
+
+// MARK: - ConfigSource
+
+/// Indicates the source of a configuration value.
+enum ConfigSource: String, CaseIterable, Sendable {
+    case global
+    case projectShared
+    case projectLocal
+
+    // MARK: Internal
+
+    var label: String {
+        switch self {
+        case .global:
+            "Global"
+        case .projectShared:
+            "Shared"
+        case .projectLocal:
+            "Local"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .global:
+            "globe"
+        case .projectShared:
+            "person.2"
+        case .projectLocal:
+            "person"
+        }
+    }
+}
+
+// MARK: - ProjectDetailTab
+
+/// Tabs available in the project detail view.
+enum ProjectDetailTab: String, CaseIterable, Identifiable, Sendable {
+    case permissions
+    case environment
+    case mcpServers
+    case hooks
+    case advanced
+
+    // MARK: Internal
+
+    var id: String {
+        rawValue
+    }
+
+    var title: String {
+        switch self {
+        case .permissions:
+            "Permissions"
+        case .environment:
+            "Environment"
+        case .mcpServers:
+            "MCP Servers"
+        case .hooks:
+            "Hooks"
+        case .advanced:
+            "Advanced"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .permissions:
+            "lock.shield"
+        case .environment:
+            "list.bullet.rectangle"
+        case .mcpServers:
+            "server.rack"
+        case .hooks:
+            "arrow.triangle.branch"
+        case .advanced:
+            "gearshape.2"
+        }
+    }
+}
+
+// MARK: - ConfigFileStatus
+
+/// Status of a configuration file.
+struct ConfigFileStatus: Sendable {
+    let exists: Bool
+    let url: URL
+}
+
+// MARK: - ProjectDetailViewModel
+
+/// View model for displaying project details.
+@MainActor
+@Observable
+final class ProjectDetailViewModel {
+    // MARK: Lifecycle
+
+    init(projectPath: String, configManager: ConfigFileManager = .shared) {
+        self.projectPath = projectPath
+        projectURL = URL(fileURLWithPath: projectPath)
+        self.configManager = configManager
+    }
+
+    // MARK: Internal
+
+    /// The path to the project directory.
+    let projectPath: String
+
+    /// The URL to the project directory.
+    let projectURL: URL
+
+    /// The currently selected tab.
+    var selectedTab: ProjectDetailTab = .permissions
+
+    /// Whether data is currently loading.
+    private(set) var isLoading = false
+
+    /// The project entry from the global config.
+    private(set) var projectEntry: ProjectEntry?
+
+    /// Global settings.
+    private(set) var globalSettings: ClaudeSettings?
+
+    /// Project-level shared settings.
+    private(set) var projectSettings: ClaudeSettings?
+
+    /// Project-level local settings.
+    private(set) var projectLocalSettings: ClaudeSettings?
+
+    /// MCP configuration for the project.
+    private(set) var mcpConfig: MCPConfig?
+
+    /// Status of the project settings file.
+    private(set) var projectSettingsStatus: ConfigFileStatus?
+
+    /// Status of the project local settings file.
+    private(set) var projectLocalSettingsStatus: ConfigFileStatus?
+
+    /// Status of the MCP config file.
+    private(set) var mcpConfigStatus: ConfigFileStatus?
+
+    /// The project name derived from the path.
+    var projectName: String {
+        projectURL.lastPathComponent
+    }
+
+    /// Whether the project directory exists.
+    var projectExists: Bool {
+        FileManager.default.fileExists(atPath: projectPath)
+    }
+
+    /// All permission rules with their sources.
+    var allPermissions: [(rule: String, type: PermissionType, source: ConfigSource)] {
+        var permissions: [(rule: String, type: PermissionType, source: ConfigSource)] = []
+
+        // Global permissions
+        if let global = globalSettings?.permissions {
+            for rule in global.allow ?? [] {
+                permissions.append((rule, .allow, .global))
+            }
+            for rule in global.deny ?? [] {
+                permissions.append((rule, .deny, .global))
+            }
+        }
+
+        // Project shared permissions
+        if let shared = projectSettings?.permissions {
+            for rule in shared.allow ?? [] {
+                permissions.append((rule, .allow, .projectShared))
+            }
+            for rule in shared.deny ?? [] {
+                permissions.append((rule, .deny, .projectShared))
+            }
+        }
+
+        // Project local permissions
+        if let local = projectLocalSettings?.permissions {
+            for rule in local.allow ?? [] {
+                permissions.append((rule, .allow, .projectLocal))
+            }
+            for rule in local.deny ?? [] {
+                permissions.append((rule, .deny, .projectLocal))
+            }
+        }
+
+        return permissions
+    }
+
+    /// All environment variables with their sources.
+    var allEnvironmentVariables: [(key: String, value: String, source: ConfigSource)] {
+        var envVars: [(key: String, value: String, source: ConfigSource)] = []
+
+        // Global env vars
+        if let global = globalSettings?.env {
+            for (key, value) in global.sorted(by: { $0.key < $1.key }) {
+                envVars.append((key, value, .global))
+            }
+        }
+
+        // Project shared env vars
+        if let shared = projectSettings?.env {
+            for (key, value) in shared.sorted(by: { $0.key < $1.key }) {
+                envVars.append((key, value, .projectShared))
+            }
+        }
+
+        // Project local env vars
+        if let local = projectLocalSettings?.env {
+            for (key, value) in local.sorted(by: { $0.key < $1.key }) {
+                envVars.append((key, value, .projectLocal))
+            }
+        }
+
+        return envVars
+    }
+
+    /// All MCP servers with their sources.
+    var allMCPServers: [(name: String, server: MCPServer, source: ConfigSource)] {
+        var servers: [(name: String, server: MCPServer, source: ConfigSource)] = []
+
+        // Project MCP config (.mcp.json)
+        if let mcpServers = mcpConfig?.mcpServers {
+            for (name, server) in mcpServers.sorted(by: { $0.key < $1.key }) {
+                servers.append((name, server, .projectShared))
+            }
+        }
+
+        // Project entry MCP servers (from ~/.claude.json)
+        if let entryServers = projectEntry?.mcpServers {
+            for (name, server) in entryServers.sorted(by: { $0.key < $1.key }) {
+                // Avoid duplicates
+                if !servers.contains(where: { $0.name == name }) {
+                    servers.append((name, server, .global))
+                }
+            }
+        }
+
+        return servers
+    }
+
+    /// All disallowed tools with their sources.
+    var allDisallowedTools: [(tool: String, source: ConfigSource)] {
+        var tools: [(tool: String, source: ConfigSource)] = []
+
+        if let global = globalSettings?.disallowedTools {
+            for tool in global {
+                tools.append((tool, .global))
+            }
+        }
+
+        if let shared = projectSettings?.disallowedTools {
+            for tool in shared {
+                tools.append((tool, .projectShared))
+            }
+        }
+
+        if let local = projectLocalSettings?.disallowedTools {
+            for tool in local {
+                tools.append((tool, .projectLocal))
+            }
+        }
+
+        return tools
+    }
+
+    /// Attribution settings with their source.
+    var attributionSettings: (attribution: Attribution, source: ConfigSource)? {
+        // Local overrides shared, shared overrides global
+        if let local = projectLocalSettings?.attribution {
+            return (local, .projectLocal)
+        }
+        if let shared = projectSettings?.attribution {
+            return (shared, .projectShared)
+        }
+        if let global = globalSettings?.attribution {
+            return (global, .global)
+        }
+        return nil
+    }
+
+    /// Loads all configuration data for the project.
+    func loadConfiguration() async {
+        isLoading = true
+
+        do {
+            // Load global config to get project entry
+            let globalConfig = try await configManager.readGlobalConfig()
+            projectEntry = globalConfig?.project(at: projectPath)
+
+            // Load global settings
+            globalSettings = try await configManager.readGlobalSettings()
+
+            // Load project settings
+            projectSettings = try await configManager.readProjectSettings(for: projectURL)
+
+            // Load project local settings
+            projectLocalSettings = try await configManager.readProjectLocalSettings(for: projectURL)
+
+            // Load MCP config
+            mcpConfig = try await configManager.readMCPConfig(for: projectURL)
+
+            // Update file statuses
+            let settingsURL = await configManager.projectSettingsURL(for: projectURL)
+            projectSettingsStatus = await ConfigFileStatus(
+                exists: configManager.fileExists(at: settingsURL),
+                url: settingsURL
+            )
+
+            let localSettingsURL = await configManager.projectLocalSettingsURL(for: projectURL)
+            projectLocalSettingsStatus = await ConfigFileStatus(
+                exists: configManager.fileExists(at: localSettingsURL),
+                url: localSettingsURL
+            )
+
+            let mcpURL = await configManager.mcpConfigURL(for: projectURL)
+            mcpConfigStatus = await ConfigFileStatus(
+                exists: configManager.fileExists(at: mcpURL),
+                url: mcpURL
+            )
+
+            Log.general.info("Loaded configuration for project: \(projectName)")
+        } catch {
+            Log.general.error("Failed to load project configuration: \(error.localizedDescription)")
+        }
+
+        isLoading = false
+    }
+
+    /// Reveals the project in Finder.
+    func revealInFinder() {
+        NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: projectPath)
+    }
+
+    /// Opens the project in Terminal.
+    func openInTerminal() {
+        let script = """
+        tell application "Terminal"
+            do script "cd \(projectPath.replacingOccurrences(of: "\"", with: "\\\""))"
+            activate
+        end tell
+        """
+        if let appleScript = NSAppleScript(source: script) {
+            var error: NSDictionary?
+            appleScript.executeAndReturnError(&error)
+            if let error {
+                Log.general.error("Failed to open Terminal: \(error)")
+            }
+        }
+    }
+
+    // MARK: Private
+
+    private let configManager: ConfigFileManager
+}
+
+// MARK: - PermissionType
+
+/// Type of permission rule.
+enum PermissionType: String, Sendable {
+    case allow
+    case deny
+
+    // MARK: Internal
+
+    var icon: String {
+        switch self {
+        case .allow:
+            "checkmark.circle.fill"
+        case .deny:
+            "xmark.circle.fill"
+        }
+    }
+}

--- a/Fig/Sources/ViewModels/ProjectExplorerViewModel.swift
+++ b/Fig/Sources/ViewModels/ProjectExplorerViewModel.swift
@@ -1,0 +1,260 @@
+import AppKit
+import Foundation
+import OSLog
+import SwiftUI
+
+// MARK: - FavoritesStorage
+
+/// Handles persistence of favorite and recent projects.
+@MainActor
+@Observable
+final class FavoritesStorage {
+    // MARK: Internal
+
+    /// Set of favorite project paths.
+    private(set) var favoriteProjectPaths: Set<String> = []
+
+    /// List of recently opened project paths (most recent first).
+    private(set) var recentProjectPaths: [String] = []
+
+    /// Maximum number of recent projects to track.
+    let maxRecentProjects = 10
+
+    /// Loads favorites and recents from UserDefaults.
+    func load() {
+        if let favorites = UserDefaults.standard.array(forKey: Self.favoritesKey) as? [String] {
+            favoriteProjectPaths = Set(favorites)
+        }
+        if let recents = UserDefaults.standard.array(forKey: Self.recentsKey) as? [String] {
+            recentProjectPaths = recents
+        }
+    }
+
+    /// Adds a project to favorites.
+    func addFavorite(_ path: String) {
+        favoriteProjectPaths.insert(path)
+        save()
+    }
+
+    /// Removes a project from favorites.
+    func removeFavorite(_ path: String) {
+        favoriteProjectPaths.remove(path)
+        save()
+    }
+
+    /// Toggles a project's favorite status.
+    func toggleFavorite(_ path: String) {
+        if favoriteProjectPaths.contains(path) {
+            removeFavorite(path)
+        } else {
+            addFavorite(path)
+        }
+    }
+
+    /// Checks if a project is a favorite.
+    func isFavorite(_ path: String) -> Bool {
+        favoriteProjectPaths.contains(path)
+    }
+
+    /// Records a project as recently opened.
+    func recordRecentProject(_ path: String) {
+        // Remove if already present
+        recentProjectPaths.removeAll { $0 == path }
+        // Insert at beginning
+        recentProjectPaths.insert(path, at: 0)
+        // Trim to max
+        if recentProjectPaths.count > maxRecentProjects {
+            recentProjectPaths = Array(recentProjectPaths.prefix(maxRecentProjects))
+        }
+        save()
+    }
+
+    // MARK: Private
+
+    private static let favoritesKey = "favoriteProjects"
+    private static let recentsKey = "recentProjects"
+
+    private func save() {
+        UserDefaults.standard.set(Array(favoriteProjectPaths), forKey: Self.favoritesKey)
+        UserDefaults.standard.set(recentProjectPaths, forKey: Self.recentsKey)
+    }
+}
+
+// MARK: - ProjectExplorerViewModel
+
+/// View model for the project explorer, managing project discovery and selection.
+@MainActor
+@Observable
+final class ProjectExplorerViewModel {
+    // MARK: Lifecycle
+
+    init(configManager: ConfigFileManager = .shared) {
+        self.configManager = configManager
+        favoritesStorage.load()
+    }
+
+    // MARK: Internal
+
+    /// Storage for favorites and recents.
+    let favoritesStorage = FavoritesStorage()
+
+    /// All discovered projects from the global config.
+    private(set) var projects: [ProjectEntry] = []
+
+    /// Whether projects are currently being loaded.
+    private(set) var isLoading = false
+
+    /// The current search query for filtering projects.
+    var searchQuery = ""
+
+    /// Error message if loading fails.
+    private(set) var errorMessage: String?
+
+    /// Whether the quick switcher is shown.
+    var isQuickSwitcherPresented = false
+
+    /// Favorite projects.
+    var favoriteProjects: [ProjectEntry] {
+        projects.filter { project in
+            guard let path = project.path else {
+                return false
+            }
+            return favoritesStorage.isFavorite(path)
+        }
+    }
+
+    /// Recent projects (excluding favorites).
+    var recentProjects: [ProjectEntry] {
+        let favoritePaths = favoritesStorage.favoriteProjectPaths
+        return favoritesStorage.recentProjectPaths.compactMap { path in
+            // Skip if it's a favorite
+            guard !favoritePaths.contains(path) else {
+                return nil
+            }
+            return projects.first { $0.path == path }
+        }
+    }
+
+    /// Projects filtered by the current search query, excluding favorites and recents.
+    var filteredProjects: [ProjectEntry] {
+        let favoritePaths = favoritesStorage.favoriteProjectPaths
+        let recentPaths = Set(favoritesStorage.recentProjectPaths)
+
+        let baseProjects = projects.filter { project in
+            guard let path = project.path else {
+                return true
+            }
+            return !favoritePaths.contains(path) && !recentPaths.contains(path)
+        }
+
+        if searchQuery.isEmpty {
+            return baseProjects
+        }
+        let query = searchQuery.lowercased()
+        return baseProjects.filter { project in
+            let nameMatch = project.name?.lowercased().contains(query) ?? false
+            let pathMatch = project.path?.lowercased().contains(query) ?? false
+            return nameMatch || pathMatch
+        }
+    }
+
+    /// All projects matching the search query (for quick switcher).
+    var searchResults: [ProjectEntry] {
+        if searchQuery.isEmpty {
+            return projects
+        }
+        let query = searchQuery.lowercased()
+        return projects.filter { project in
+            let nameMatch = project.name?.lowercased().contains(query) ?? false
+            let pathMatch = project.path?.lowercased().contains(query) ?? false
+            return nameMatch || pathMatch
+        }
+    }
+
+    /// Checks if a project directory exists on disk.
+    func projectExists(_ project: ProjectEntry) -> Bool {
+        guard let path = project.path else {
+            return false
+        }
+        return FileManager.default.fileExists(atPath: path)
+    }
+
+    /// Loads projects from the global configuration file.
+    func loadProjects() async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            let config = try await configManager.readGlobalConfig()
+            projects = config?.allProjects ?? []
+            Log.general.info("Loaded \(projects.count) projects")
+        } catch {
+            errorMessage = error.localizedDescription
+            Log.general.error("Failed to load projects: \(error.localizedDescription)")
+        }
+
+        isLoading = false
+    }
+
+    /// Returns the MCP server count for a project.
+    func mcpServerCount(for project: ProjectEntry) -> Int {
+        project.mcpServers?.count ?? 0
+    }
+
+    /// Toggles favorite status for a project.
+    func toggleFavorite(_ project: ProjectEntry) {
+        guard let path = project.path else {
+            return
+        }
+        favoritesStorage.toggleFavorite(path)
+    }
+
+    /// Checks if a project is a favorite.
+    func isFavorite(_ project: ProjectEntry) -> Bool {
+        guard let path = project.path else {
+            return false
+        }
+        return favoritesStorage.isFavorite(path)
+    }
+
+    /// Records a project as recently opened.
+    func recordRecentProject(_ project: ProjectEntry) {
+        guard let path = project.path else {
+            return
+        }
+        favoritesStorage.recordRecentProject(path)
+    }
+
+    /// Reveals a project in Finder.
+    func revealInFinder(_ project: ProjectEntry) {
+        guard let path = project.path else {
+            return
+        }
+        let url = URL(fileURLWithPath: path)
+        NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: url.path)
+    }
+
+    /// Opens a project in Terminal.
+    func openInTerminal(_ project: ProjectEntry) {
+        guard let path = project.path else {
+            return
+        }
+        let script = """
+        tell application "Terminal"
+            do script "cd \(path.replacingOccurrences(of: "\"", with: "\\\""))"
+            activate
+        end tell
+        """
+        if let appleScript = NSAppleScript(source: script) {
+            var error: NSDictionary?
+            appleScript.executeAndReturnError(&error)
+            if let error {
+                Log.general.error("Failed to open Terminal: \(error)")
+            }
+        }
+    }
+
+    // MARK: Private
+
+    private let configManager: ConfigFileManager
+}

--- a/Fig/Sources/Views/ConfigTabViews.swift
+++ b/Fig/Sources/Views/ConfigTabViews.swift
@@ -1,0 +1,618 @@
+import SwiftUI
+
+// MARK: - SourceBadge
+
+/// A small badge indicating the source of a configuration value.
+struct SourceBadge: View {
+    // MARK: Internal
+
+    let source: ConfigSource
+
+    var body: some View {
+        HStack(spacing: 2) {
+            Image(systemName: source.icon)
+                .font(.caption2)
+            Text(source.label)
+                .font(.caption2)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(backgroundColor.opacity(0.2), in: RoundedRectangle(cornerRadius: 4))
+        .foregroundStyle(backgroundColor)
+    }
+
+    // MARK: Private
+
+    private var backgroundColor: Color {
+        switch source {
+        case .global:
+            .blue
+        case .projectShared:
+            .purple
+        case .projectLocal:
+            .orange
+        }
+    }
+}
+
+// MARK: - PermissionsTabView
+
+/// Tab view displaying permission rules.
+struct PermissionsTabView: View {
+    // MARK: Internal
+
+    var permissions: Permissions?
+    var allPermissions: [(rule: String, type: PermissionType, source: ConfigSource)]?
+    var source: ConfigSource?
+    var emptyMessage = "No permission rules configured."
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                // Source legend for project views
+                if allPermissions != nil {
+                    SourceLegend()
+                }
+
+                // Allow rules
+                GroupBox {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Label("Allow Rules", systemImage: "checkmark.circle.fill")
+                            .font(.headline)
+                            .foregroundStyle(.green)
+
+                        let allowRules = allowPermissions
+                        if allowRules.isEmpty {
+                            Text("No allow rules configured.")
+                                .foregroundStyle(.secondary)
+                                .padding(.vertical, 8)
+                        } else {
+                            ForEach(Array(allowRules.enumerated()), id: \.offset) { _, item in
+                                PermissionRuleRow(
+                                    rule: item.rule,
+                                    type: .allow,
+                                    source: item.source
+                                )
+                            }
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+
+                // Deny rules
+                GroupBox {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Label("Deny Rules", systemImage: "xmark.circle.fill")
+                            .font(.headline)
+                            .foregroundStyle(.red)
+
+                        let denyRules = denyPermissions
+                        if denyRules.isEmpty {
+                            Text("No deny rules configured.")
+                                .foregroundStyle(.secondary)
+                                .padding(.vertical, 8)
+                        } else {
+                            ForEach(Array(denyRules.enumerated()), id: \.offset) { _, item in
+                                PermissionRuleRow(
+                                    rule: item.rule,
+                                    type: .deny,
+                                    source: item.source
+                                )
+                            }
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    // MARK: Private
+
+    private var allowPermissions: [(rule: String, source: ConfigSource)] {
+        if let allPermissions {
+            return allPermissions.filter { $0.type == .allow }.map { ($0.rule, $0.source) }
+        }
+        if let permissions, let source {
+            return (permissions.allow ?? []).map { ($0, source) }
+        }
+        return []
+    }
+
+    private var denyPermissions: [(rule: String, source: ConfigSource)] {
+        if let allPermissions {
+            return allPermissions.filter { $0.type == .deny }.map { ($0.rule, $0.source) }
+        }
+        if let permissions, let source {
+            return (permissions.deny ?? []).map { ($0, source) }
+        }
+        return []
+    }
+}
+
+// MARK: - PermissionRuleRow
+
+/// A row displaying a single permission rule.
+struct PermissionRuleRow: View {
+    let rule: String
+    let type: PermissionType
+    let source: ConfigSource
+
+    var body: some View {
+        HStack {
+            Image(systemName: type.icon)
+                .foregroundStyle(type == .allow ? .green : .red)
+                .frame(width: 20)
+
+            Text(rule)
+                .font(.system(.body, design: .monospaced))
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Spacer()
+
+            SourceBadge(source: source)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+// MARK: - EnvironmentTabView
+
+/// Tab view displaying environment variables.
+struct EnvironmentTabView: View {
+    let envVars: [(key: String, value: String, source: ConfigSource)]
+    var emptyMessage = "No environment variables configured."
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if !envVars.isEmpty {
+                    SourceLegend()
+                }
+
+                if envVars.isEmpty {
+                    ContentUnavailableView(
+                        "No Environment Variables",
+                        systemImage: "list.bullet.rectangle",
+                        description: Text(emptyMessage)
+                    )
+                } else {
+                    GroupBox {
+                        VStack(alignment: .leading, spacing: 0) {
+                            ForEach(Array(envVars.enumerated()), id: \.offset) { index, item in
+                                if index > 0 {
+                                    Divider()
+                                }
+                                EnvironmentVariableRow(
+                                    key: item.key,
+                                    value: item.value,
+                                    source: item.source
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+// MARK: - EnvironmentVariableRow
+
+/// A row displaying a single environment variable.
+struct EnvironmentVariableRow: View {
+    // MARK: Internal
+
+    let key: String
+    let value: String
+    let source: ConfigSource
+
+    var body: some View {
+        HStack(alignment: .top) {
+            Text(key)
+                .font(.system(.body, design: .monospaced))
+                .fontWeight(.medium)
+                .frame(minWidth: 200, alignment: .leading)
+
+            Text("=")
+                .foregroundStyle(.secondary)
+
+            Group {
+                if isValueVisible || !isSensitive {
+                    Text(value)
+                        .font(.system(.body, design: .monospaced))
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                } else {
+                    Text(String(repeating: "\u{2022}", count: min(value.count, 20)))
+                        .font(.system(.body, design: .monospaced))
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if isSensitive {
+                Button {
+                    isValueVisible.toggle()
+                } label: {
+                    Image(systemName: isValueVisible ? "eye.slash" : "eye")
+                        .font(.caption)
+                }
+                .buttonStyle(.plain)
+            }
+
+            SourceBadge(source: source)
+        }
+        .padding(.vertical, 8)
+    }
+
+    // MARK: Private
+
+    @State private var isValueVisible = false
+
+    private var isSensitive: Bool {
+        let sensitivePatterns = ["token", "key", "secret", "password", "credential", "api"]
+        let lowercaseKey = key.lowercased()
+        return sensitivePatterns.contains { lowercaseKey.contains($0) }
+    }
+}
+
+// MARK: - MCPServersTabView
+
+/// Tab view displaying MCP server configurations.
+struct MCPServersTabView: View {
+    let servers: [(name: String, server: MCPServer, source: ConfigSource)]
+    var emptyMessage = "No MCP servers configured."
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if !servers.isEmpty {
+                    SourceLegend()
+                }
+
+                if servers.isEmpty {
+                    ContentUnavailableView(
+                        "No MCP Servers",
+                        systemImage: "server.rack",
+                        description: Text(emptyMessage)
+                    )
+                } else {
+                    ForEach(Array(servers.enumerated()), id: \.offset) { _, item in
+                        MCPServerCard(
+                            name: item.name,
+                            server: item.server,
+                            source: item.source
+                        )
+                    }
+                }
+
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+// MARK: - MCPServerCard
+
+/// A card displaying MCP server details.
+struct MCPServerCard: View {
+    // MARK: Internal
+
+    let name: String
+    let server: MCPServer
+    let source: ConfigSource
+
+    var body: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 8) {
+                // Header
+                HStack {
+                    Image(systemName: server.isHTTP ? "globe" : "terminal")
+                        .foregroundStyle(server.isHTTP ? .blue : .green)
+
+                    Text(name)
+                        .font(.headline)
+
+                    Text(server.isHTTP ? "HTTP" : "Stdio")
+                        .font(.caption)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.quaternary, in: RoundedRectangle(cornerRadius: 4))
+
+                    Spacer()
+
+                    SourceBadge(source: source)
+
+                    Button {
+                        withAnimation {
+                            isExpanded.toggle()
+                        }
+                    } label: {
+                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                            .font(.caption)
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                // Summary line
+                if server.isHTTP {
+                    if let url = server.url {
+                        Text(url)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                } else if let command = server.command {
+                    HStack(spacing: 4) {
+                        Text(command)
+                            .font(.system(.caption, design: .monospaced))
+                        if let args = server.args, !args.isEmpty {
+                            Text(args.joined(separator: " "))
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
+                }
+
+                // Expanded details
+                if isExpanded {
+                    Divider()
+
+                    if server.isHTTP {
+                        if let headers = server.headers, !headers.isEmpty {
+                            Text("Headers:")
+                                .font(.caption)
+                                .fontWeight(.medium)
+                            ForEach(Array(headers.keys.sorted()), id: \.self) { key in
+                                HStack {
+                                    Text(key)
+                                        .font(.system(.caption, design: .monospaced))
+                                    Text(":")
+                                        .foregroundStyle(.secondary)
+                                    Text(maskSensitiveValue(key: key, value: headers[key] ?? ""))
+                                        .font(.system(.caption, design: .monospaced))
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    } else {
+                        if let env = server.env, !env.isEmpty {
+                            Text("Environment:")
+                                .font(.caption)
+                                .fontWeight(.medium)
+                            ForEach(Array(env.keys.sorted()), id: \.self) { key in
+                                HStack {
+                                    Text(key)
+                                        .font(.system(.caption, design: .monospaced))
+                                    Text("=")
+                                        .foregroundStyle(.secondary)
+                                    Text(maskSensitiveValue(key: key, value: env[key] ?? ""))
+                                        .font(.system(.caption, design: .monospaced))
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: Private
+
+    @State private var isExpanded = false
+
+    private func maskSensitiveValue(key: String, value: String) -> String {
+        let sensitivePatterns = ["token", "key", "secret", "password", "credential", "api", "authorization"]
+        let lowercaseKey = key.lowercased()
+        if sensitivePatterns.contains(where: { lowercaseKey.contains($0) }) {
+            return String(repeating: "\u{2022}", count: min(value.count, 20))
+        }
+        return value
+    }
+}
+
+// MARK: - HooksTabView
+
+/// Tab view displaying hook configurations.
+struct HooksTabView: View {
+    // MARK: Internal
+
+    let globalHooks: [String: [HookGroup]]?
+    let projectHooks: [String: [HookGroup]]?
+    let localHooks: [String: [HookGroup]]?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                SourceLegend()
+
+                if allHooksEmpty {
+                    ContentUnavailableView(
+                        "No Hooks Configured",
+                        systemImage: "arrow.triangle.branch",
+                        description: Text(
+                            "Hooks allow you to run custom commands before or after Claude Code operations."
+                        )
+                    )
+                } else {
+                    // List all hook events
+                    ForEach(allHookEvents, id: \.self) { event in
+                        HookEventSection(
+                            event: event,
+                            globalGroups: globalHooks?[event],
+                            projectGroups: projectHooks?[event],
+                            localGroups: localHooks?[event]
+                        )
+                    }
+                }
+
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    // MARK: Private
+
+    private var allHooksEmpty: Bool {
+        (globalHooks?.isEmpty ?? true) &&
+            (projectHooks?.isEmpty ?? true) &&
+            (localHooks?.isEmpty ?? true)
+    }
+
+    private var allHookEvents: [String] {
+        var events = Set<String>()
+        if let global = globalHooks {
+            events.formUnion(global.keys)
+        }
+        if let project = projectHooks {
+            events.formUnion(project.keys)
+        }
+        if let local = localHooks {
+            events.formUnion(local.keys)
+        }
+        return events.sorted()
+    }
+}
+
+// MARK: - HookEventSection
+
+/// Section showing hooks for a specific event.
+struct HookEventSection: View {
+    let event: String
+    let globalGroups: [HookGroup]?
+    let projectGroups: [HookGroup]?
+    let localGroups: [HookGroup]?
+
+    var body: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(event)
+                    .font(.headline)
+
+                // Global hooks
+                if let groups = globalGroups {
+                    ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
+                        HookGroupRow(group: group, source: .global)
+                    }
+                }
+
+                // Project hooks
+                if let groups = projectGroups {
+                    ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
+                        HookGroupRow(group: group, source: .projectShared)
+                    }
+                }
+
+                // Local hooks
+                if let groups = localGroups {
+                    ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
+                        HookGroupRow(group: group, source: .projectLocal)
+                    }
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+}
+
+// MARK: - HookGroupRow
+
+/// A row displaying a hook group.
+struct HookGroupRow: View {
+    let group: HookGroup
+    let source: ConfigSource
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                if let matcher = group.matcher {
+                    Text("Matcher: \(matcher)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                SourceBadge(source: source)
+            }
+
+            if let hooks = group.hooks {
+                ForEach(Array(hooks.enumerated()), id: \.offset) { _, hook in
+                    HStack {
+                        Image(systemName: "terminal")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(hook.command ?? "No command")
+                            .font(.system(.caption, design: .monospaced))
+                            .lineLimit(1)
+                    }
+                    .padding(.leading, 16)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 8)
+        .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+// MARK: - SourceLegend
+
+/// Legend explaining source badge colors.
+struct SourceLegend: View {
+    var body: some View {
+        HStack(spacing: 16) {
+            Text("Source:")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            ForEach(ConfigSource.allCases, id: \.rawValue) { source in
+                SourceBadge(source: source)
+            }
+        }
+        .padding(.bottom, 8)
+    }
+}
+
+#Preview("Permissions Tab") {
+    PermissionsTabView(
+        allPermissions: [
+            ("Bash(npm run *)", .allow, .global),
+            ("Read(src/**)", .allow, .projectShared),
+            ("Read(.env)", .deny, .projectLocal),
+        ]
+    )
+    .padding()
+    .frame(width: 600, height: 400)
+}
+
+#Preview("Environment Tab") {
+    EnvironmentTabView(
+        envVars: [
+            ("CLAUDE_CODE_MAX_OUTPUT_TOKENS", "16384", .global),
+            ("API_KEY", "sk-1234567890", .projectLocal),
+        ]
+    )
+    .padding()
+    .frame(width: 600, height: 400)
+}
+
+#Preview("MCP Servers Tab") {
+    MCPServersTabView(
+        servers: [
+            ("github", .stdio(command: "npx", args: ["-y", "@mcp/server-github"]), .projectShared),
+            ("api", .http(url: "https://mcp.example.com"), .global),
+        ]
+    )
+    .padding()
+    .frame(width: 600, height: 400)
+}

--- a/Fig/Sources/Views/ContentView.swift
+++ b/Fig/Sources/Views/ContentView.swift
@@ -6,17 +6,28 @@ struct ContentView: View {
 
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
-            SidebarView(selectedItem: $selectedItem)
+            SidebarView(selection: $selection, viewModel: viewModel)
         } detail: {
-            DetailView(selectedItem: selectedItem)
+            DetailView(selection: selection)
         }
         .navigationSplitViewStyle(.balanced)
+        .onKeyPress(keys: [KeyEquivalent("k")], phases: .down) { press in
+            guard press.modifiers.contains(.command) else {
+                return .ignored
+            }
+            viewModel.isQuickSwitcherPresented = true
+            return .handled
+        }
+        .sheet(isPresented: $viewModel.isQuickSwitcherPresented) {
+            QuickSwitcherView(viewModel: viewModel, selection: $selection)
+        }
     }
 
     // MARK: Private
 
-    @State private var selectedItem: SidebarItem?
+    @State private var selection: NavigationSelection?
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
+    @State private var viewModel = ProjectExplorerViewModel()
 }
 
 #Preview {

--- a/Fig/Sources/Views/DetailView.swift
+++ b/Fig/Sources/Views/DetailView.swift
@@ -2,28 +2,16 @@ import SwiftUI
 
 /// The detail view displaying content for the selected sidebar item.
 struct DetailView: View {
-    let selectedItem: SidebarItem?
+    let selection: NavigationSelection?
 
     var body: some View {
         Group {
-            if let item = selectedItem {
-                VStack(spacing: 16) {
-                    Image(systemName: item.icon)
-                        .font(.system(size: 64))
-                        .foregroundStyle(.secondary)
-
-                    Text(item.title)
-                        .font(.largeTitle)
-                        .fontWeight(.semibold)
-
-                    Text(item.description)
-                        .font(.body)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                        .frame(maxWidth: 400)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
+            switch selection {
+            case .globalSettings:
+                GlobalSettingsDetailView()
+            case let .project(path):
+                ProjectDetailView(projectPath: path)
+            case nil:
                 ContentUnavailableView(
                     "Select an Item",
                     systemImage: "sidebar.left",
@@ -31,14 +19,21 @@ struct DetailView: View {
                 )
             }
         }
-        .frame(minWidth: 400)
+        .frame(minWidth: 500)
     }
 }
 
-#Preview {
-    DetailView(selectedItem: .home)
+#Preview("Global Settings") {
+    DetailView(selection: .globalSettings)
+        .frame(width: 700, height: 500)
+}
+
+#Preview("Project") {
+    DetailView(selection: .project("/Users/test/project"))
+        .frame(width: 700, height: 500)
 }
 
 #Preview("No Selection") {
-    DetailView(selectedItem: nil)
+    DetailView(selection: nil)
+        .frame(width: 700, height: 500)
 }

--- a/Fig/Sources/Views/GlobalSettingsDetailView.swift
+++ b/Fig/Sources/Views/GlobalSettingsDetailView.swift
@@ -1,0 +1,375 @@
+import SwiftUI
+
+// MARK: - GlobalSettingsViewModel
+
+/// View model for global settings.
+@MainActor
+@Observable
+final class GlobalSettingsViewModel {
+    // MARK: Lifecycle
+
+    init(configManager: ConfigFileManager = .shared) {
+        self.configManager = configManager
+    }
+
+    // MARK: Internal
+
+    /// Whether data is loading.
+    private(set) var isLoading = false
+
+    /// The global settings.
+    private(set) var settings: ClaudeSettings?
+
+    /// The global legacy config.
+    private(set) var legacyConfig: LegacyConfig?
+
+    /// The selected tab.
+    var selectedTab: GlobalSettingsTab = .permissions
+
+    /// Status of the global settings file.
+    private(set) var settingsFileStatus: ConfigFileStatus?
+
+    /// Status of the global config file.
+    private(set) var configFileStatus: ConfigFileStatus?
+
+    /// Path to the global settings file.
+    private(set) var globalSettingsPath: String?
+
+    /// Path to the global settings directory.
+    private(set) var globalSettingsDirectoryPath: String?
+
+    /// Global MCP servers from the legacy config.
+    var globalMCPServers: [(name: String, server: MCPServer)] {
+        legacyConfig?.mcpServers?.map { ($0.key, $0.value) }.sorted { $0.0 < $1.0 } ?? []
+    }
+
+    /// Loads global settings.
+    func load() async {
+        isLoading = true
+
+        do {
+            settings = try await configManager.readGlobalSettings()
+            legacyConfig = try await configManager.readGlobalConfig()
+
+            // Load file statuses
+            let settingsURL = await configManager.globalSettingsURL
+            settingsFileStatus = await ConfigFileStatus(
+                exists: configManager.fileExists(at: settingsURL),
+                url: settingsURL
+            )
+            globalSettingsPath = settingsURL.path
+            globalSettingsDirectoryPath = await configManager.globalSettingsDirectory.path
+
+            let configURL = await configManager.globalConfigURL
+            configFileStatus = await ConfigFileStatus(
+                exists: configManager.fileExists(at: configURL),
+                url: configURL
+            )
+        } catch {
+            Log.general.error("Failed to load global settings: \(error.localizedDescription)")
+        }
+
+        isLoading = false
+    }
+
+    /// Reveals the settings file in Finder.
+    func revealSettingsInFinder() {
+        guard let path = globalSettingsPath,
+              let dirPath = globalSettingsDirectoryPath
+        else {
+            return
+        }
+        NSWorkspace.shared.selectFile(path, inFileViewerRootedAtPath: dirPath)
+    }
+
+    // MARK: Private
+
+    private let configManager: ConfigFileManager
+}
+
+// MARK: - GlobalSettingsTab
+
+/// Tabs for global settings view.
+enum GlobalSettingsTab: String, CaseIterable, Identifiable, Sendable {
+    case permissions
+    case environment
+    case mcpServers
+    case advanced
+
+    // MARK: Internal
+
+    var id: String {
+        rawValue
+    }
+
+    var title: String {
+        switch self {
+        case .permissions:
+            "Permissions"
+        case .environment:
+            "Environment"
+        case .mcpServers:
+            "MCP Servers"
+        case .advanced:
+            "Advanced"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .permissions:
+            "lock.shield"
+        case .environment:
+            "list.bullet.rectangle"
+        case .mcpServers:
+            "server.rack"
+        case .advanced:
+            "gearshape.2"
+        }
+    }
+}
+
+// MARK: - GlobalSettingsDetailView
+
+/// Detail view for global settings.
+struct GlobalSettingsDetailView: View {
+    // MARK: Internal
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            GlobalSettingsHeaderView(viewModel: viewModel)
+
+            Divider()
+
+            // Tab content
+            if viewModel.isLoading {
+                ProgressView("Loading settings...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                TabView(selection: $viewModel.selectedTab) {
+                    ForEach(GlobalSettingsTab.allCases) { tab in
+                        globalTabContent(for: tab)
+                            .tabItem {
+                                Label(tab.title, systemImage: tab.icon)
+                            }
+                            .tag(tab)
+                    }
+                }
+                .padding()
+            }
+        }
+        .frame(minWidth: 500)
+        .task {
+            await viewModel.load()
+        }
+    }
+
+    // MARK: Private
+
+    @State private var viewModel = GlobalSettingsViewModel()
+
+    @ViewBuilder
+    private func globalTabContent(for tab: GlobalSettingsTab) -> some View {
+        switch tab {
+        case .permissions:
+            PermissionsTabView(
+                permissions: viewModel.settings?.permissions,
+                source: .global
+            )
+        case .environment:
+            EnvironmentTabView(
+                envVars: viewModel.settings?.env?.map { ($0.key, $0.value, ConfigSource.global) } ?? [],
+                emptyMessage: "No global environment variables configured."
+            )
+        case .mcpServers:
+            MCPServersTabView(
+                servers: viewModel.globalMCPServers.map { ($0.name, $0.server, ConfigSource.global) },
+                emptyMessage: "No global MCP servers configured."
+            )
+        case .advanced:
+            GlobalAdvancedTabView(
+                settings: viewModel.settings,
+                legacyConfig: viewModel.legacyConfig
+            )
+        }
+    }
+}
+
+// MARK: - GlobalSettingsHeaderView
+
+/// Header view for global settings.
+struct GlobalSettingsHeaderView: View {
+    @Bindable var viewModel: GlobalSettingsViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "globe")
+                    .font(.title)
+                    .foregroundStyle(.blue)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Global Settings")
+                        .font(.title2)
+                        .fontWeight(.semibold)
+
+                    Button {
+                        viewModel.revealSettingsInFinder()
+                    } label: {
+                        Text("~/.claude/settings.json")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { isHovered in
+                        if isHovered {
+                            NSCursor.pointingHand.push()
+                        } else {
+                            NSCursor.pop()
+                        }
+                    }
+                }
+
+                Spacer()
+
+                // File status badges
+                HStack(spacing: 8) {
+                    if let status = viewModel.settingsFileStatus {
+                        FileStatusBadge(
+                            label: "settings.json",
+                            exists: status.exists
+                        )
+                    }
+                    if let status = viewModel.configFileStatus {
+                        FileStatusBadge(
+                            label: ".claude.json",
+                            exists: status.exists
+                        )
+                    }
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+// MARK: - GlobalAdvancedTabView
+
+/// Advanced settings tab for global settings.
+struct GlobalAdvancedTabView: View {
+    let settings: ClaudeSettings?
+    let legacyConfig: LegacyConfig?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                // Attribution settings
+                GroupBox("Attribution") {
+                    if let attribution = settings?.attribution {
+                        VStack(alignment: .leading, spacing: 8) {
+                            AttributionRow(
+                                label: "Commit Attribution",
+                                enabled: attribution.commits ?? false
+                            )
+                            AttributionRow(
+                                label: "Pull Request Attribution",
+                                enabled: attribution.pullRequests ?? false
+                            )
+                        }
+                        .padding(.vertical, 4)
+                    } else {
+                        Text("No attribution settings configured.")
+                            .foregroundStyle(.secondary)
+                            .padding(.vertical, 8)
+                    }
+                }
+
+                // Disallowed tools
+                GroupBox("Disallowed Tools") {
+                    if let tools = settings?.disallowedTools, !tools.isEmpty {
+                        VStack(alignment: .leading, spacing: 4) {
+                            ForEach(tools, id: \.self) { tool in
+                                HStack {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundStyle(.red)
+                                    Text(tool)
+                                        .font(.system(.body, design: .monospaced))
+                                }
+                            }
+                        }
+                        .padding(.vertical, 4)
+                    } else {
+                        Text("No tools are globally disallowed.")
+                            .foregroundStyle(.secondary)
+                            .padding(.vertical, 8)
+                    }
+                }
+
+                // Project count
+                GroupBox("Statistics") {
+                    HStack {
+                        Label(
+                            "\(legacyConfig?.projects?.count ?? 0) projects",
+                            systemImage: "folder"
+                        )
+                        Spacer()
+                        Label(
+                            "\(legacyConfig?.mcpServers?.count ?? 0) global MCP servers",
+                            systemImage: "server.rack"
+                        )
+                    }
+                    .padding(.vertical, 4)
+                }
+
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+// MARK: - AttributionRow
+
+/// A row showing attribution status.
+struct AttributionRow: View {
+    let label: String
+    let enabled: Bool
+
+    var body: some View {
+        HStack {
+            Image(systemName: enabled ? "checkmark.circle.fill" : "circle")
+                .foregroundStyle(enabled ? .green : .secondary)
+            Text(label)
+            Spacer()
+            Text(enabled ? "Enabled" : "Disabled")
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - FileStatusBadge
+
+/// A badge showing file existence status.
+struct FileStatusBadge: View {
+    let label: String
+    let exists: Bool
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: exists ? "checkmark.circle.fill" : "xmark.circle")
+                .foregroundStyle(exists ? .green : .orange)
+                .font(.caption)
+            Text(label)
+                .font(.caption)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+#Preview {
+    GlobalSettingsDetailView()
+        .frame(width: 700, height: 500)
+}

--- a/Fig/Sources/Views/ProjectDetailView.swift
+++ b/Fig/Sources/Views/ProjectDetailView.swift
@@ -1,0 +1,385 @@
+import SwiftUI
+
+// MARK: - ProjectDetailView
+
+/// Detail view for a selected project showing tabbed configuration.
+struct ProjectDetailView: View {
+    // MARK: Lifecycle
+
+    init(projectPath: String) {
+        _viewModel = State(initialValue: ProjectDetailViewModel(projectPath: projectPath))
+    }
+
+    // MARK: Internal
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            ProjectHeaderView(viewModel: viewModel)
+
+            Divider()
+
+            // Tab content
+            if viewModel.isLoading {
+                ProgressView("Loading configuration...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if !viewModel.projectExists {
+                ContentUnavailableView(
+                    "Project Not Found",
+                    systemImage: "folder.badge.questionmark",
+                    description: Text("The project directory no longer exists at:\n\(viewModel.projectPath)")
+                )
+            } else {
+                TabView(selection: $viewModel.selectedTab) {
+                    ForEach(ProjectDetailTab.allCases) { tab in
+                        tabContent(for: tab)
+                            .tabItem {
+                                Label(tab.title, systemImage: tab.icon)
+                            }
+                            .tag(tab)
+                    }
+                }
+                .padding()
+            }
+        }
+        .frame(minWidth: 500)
+        .task {
+            await viewModel.loadConfiguration()
+        }
+    }
+
+    // MARK: Private
+
+    @State private var viewModel: ProjectDetailViewModel
+
+    @ViewBuilder
+    private func tabContent(for tab: ProjectDetailTab) -> some View {
+        switch tab {
+        case .permissions:
+            PermissionsTabView(
+                allPermissions: viewModel.allPermissions,
+                emptyMessage: "No permission rules configured for this project."
+            )
+        case .environment:
+            EnvironmentTabView(
+                envVars: viewModel.allEnvironmentVariables,
+                emptyMessage: "No environment variables configured for this project."
+            )
+        case .mcpServers:
+            MCPServersTabView(
+                servers: viewModel.allMCPServers,
+                emptyMessage: "No MCP servers configured for this project."
+            )
+        case .hooks:
+            HooksTabView(
+                globalHooks: viewModel.globalSettings?.hooks,
+                projectHooks: viewModel.projectSettings?.hooks,
+                localHooks: viewModel.projectLocalSettings?.hooks
+            )
+        case .advanced:
+            AdvancedTabView(viewModel: viewModel)
+        }
+    }
+}
+
+// MARK: - ProjectHeaderView
+
+/// Header view showing project metadata.
+struct ProjectHeaderView: View {
+    // MARK: Internal
+
+    @Bindable var viewModel: ProjectDetailViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                // Project icon
+                Image(systemName: viewModel.projectExists ? "folder.fill" : "folder.badge.questionmark")
+                    .font(.title)
+                    .foregroundStyle(viewModel.projectExists ? .blue : .orange)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(viewModel.projectName)
+                        .font(.title2)
+                        .fontWeight(.semibold)
+
+                    Button {
+                        viewModel.revealInFinder()
+                    } label: {
+                        Text(abbreviatePath(viewModel.projectPath))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!viewModel.projectExists)
+                    .onHover { isHovered in
+                        if isHovered, viewModel.projectExists {
+                            NSCursor.pointingHand.push()
+                        } else {
+                            NSCursor.pop()
+                        }
+                    }
+                }
+
+                Spacer()
+
+                // Action buttons
+                HStack(spacing: 8) {
+                    Button {
+                        viewModel.revealInFinder()
+                    } label: {
+                        Label("Reveal", systemImage: "folder")
+                    }
+                    .disabled(!viewModel.projectExists)
+
+                    Button {
+                        viewModel.openInTerminal()
+                    } label: {
+                        Label("Terminal", systemImage: "terminal")
+                    }
+                    .disabled(!viewModel.projectExists)
+                }
+            }
+
+            // Config file status badges
+            HStack(spacing: 8) {
+                if let status = viewModel.projectSettingsStatus {
+                    ConfigFileBadge(
+                        label: "settings.json",
+                        status: status,
+                        source: .projectShared
+                    )
+                }
+                if let status = viewModel.projectLocalSettingsStatus {
+                    ConfigFileBadge(
+                        label: "settings.local.json",
+                        status: status,
+                        source: .projectLocal
+                    )
+                }
+                if let status = viewModel.mcpConfigStatus {
+                    ConfigFileBadge(
+                        label: ".mcp.json",
+                        status: status,
+                        source: .projectShared
+                    )
+                }
+            }
+        }
+        .padding()
+    }
+
+    // MARK: Private
+
+    private func abbreviatePath(_ path: String) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        if path.hasPrefix(home) {
+            return "~" + path.dropFirst(home.count)
+        }
+        return path
+    }
+}
+
+// MARK: - ConfigFileBadge
+
+/// Badge showing config file status with source color.
+struct ConfigFileBadge: View {
+    // MARK: Internal
+
+    let label: String
+    let status: ConfigFileStatus
+    let source: ConfigSource
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: status.exists ? "checkmark.circle.fill" : "plus.circle.dashed")
+                .foregroundStyle(status.exists ? .green : .secondary)
+                .font(.caption)
+            Text(label)
+                .font(.caption)
+            Image(systemName: source.icon)
+                .foregroundStyle(sourceColor)
+                .font(.caption2)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+        .help(status.exists ? "File exists" : "File not created yet")
+    }
+
+    // MARK: Private
+
+    private var sourceColor: Color {
+        switch source {
+        case .global:
+            .blue
+        case .projectShared:
+            .purple
+        case .projectLocal:
+            .orange
+        }
+    }
+}
+
+// MARK: - AdvancedTabView
+
+/// Advanced settings tab for a project.
+struct AdvancedTabView: View {
+    @Bindable var viewModel: ProjectDetailViewModel
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                // Project entry info
+                if let entry = viewModel.projectEntry {
+                    GroupBox("Project Status") {
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                Text("Trust Dialog Accepted")
+                                Spacer()
+                                Image(systemName: entry.hasTrustDialogAccepted == true
+                                    ? "checkmark.circle.fill" : "xmark.circle")
+                                    .foregroundStyle(entry.hasTrustDialogAccepted == true ? .green : .secondary)
+                            }
+
+                            if let tools = entry.allowedTools, !tools.isEmpty {
+                                Divider()
+                                Text("Allowed Tools")
+                                    .font(.headline)
+                                FlowLayout(spacing: 4) {
+                                    ForEach(tools, id: \.self) { tool in
+                                        Text(tool)
+                                            .font(.caption)
+                                            .padding(.horizontal, 8)
+                                            .padding(.vertical, 4)
+                                            .background(.green.opacity(0.2), in: RoundedRectangle(cornerRadius: 4))
+                                    }
+                                }
+                            }
+
+                            if let history = entry.history, !history.isEmpty {
+                                Divider()
+                                HStack {
+                                    Text("Conversation History")
+                                    Spacer()
+                                    Text("\(history.count) conversations")
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+
+                // Attribution settings
+                GroupBox("Attribution") {
+                    if let (attribution, source) = viewModel.attributionSettings {
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                SourceBadge(source: source)
+                                Spacer()
+                            }
+                            AttributionRow(
+                                label: "Commit Attribution",
+                                enabled: attribution.commits ?? false
+                            )
+                            AttributionRow(
+                                label: "Pull Request Attribution",
+                                enabled: attribution.pullRequests ?? false
+                            )
+                        }
+                        .padding(.vertical, 4)
+                    } else {
+                        Text("Using default attribution settings.")
+                            .foregroundStyle(.secondary)
+                            .padding(.vertical, 8)
+                    }
+                }
+
+                // Disallowed tools
+                GroupBox("Disallowed Tools") {
+                    let tools = viewModel.allDisallowedTools
+                    if tools.isEmpty {
+                        Text("No tools are disallowed for this project.")
+                            .foregroundStyle(.secondary)
+                            .padding(.vertical, 8)
+                    } else {
+                        VStack(alignment: .leading, spacing: 4) {
+                            ForEach(Array(tools.enumerated()), id: \.offset) { _, item in
+                                HStack {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundStyle(.red)
+                                    Text(item.tool)
+                                        .font(.system(.body, design: .monospaced))
+                                    Spacer()
+                                    SourceBadge(source: item.source)
+                                }
+                            }
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+// MARK: - FlowLayout
+
+/// A simple flow layout for wrapping items.
+struct FlowLayout: Layout {
+    // MARK: Internal
+
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()) -> CGSize {
+        let result = layout(proposal: proposal, subviews: subviews)
+        return result.size
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()) {
+        let result = layout(proposal: proposal, subviews: subviews)
+        for (index, position) in result.positions.enumerated() {
+            subviews[index].place(
+                at: CGPoint(x: bounds.minX + position.x, y: bounds.minY + position.y),
+                proposal: .unspecified
+            )
+        }
+    }
+
+    // MARK: Private
+
+    private func layout(proposal: ProposedViewSize, subviews: Subviews) -> (size: CGSize, positions: [CGPoint]) {
+        let maxWidth = proposal.width ?? .infinity
+        var positions: [CGPoint] = []
+        var currentX: CGFloat = 0
+        var currentY: CGFloat = 0
+        var lineHeight: CGFloat = 0
+        var totalHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+
+            if currentX + size.width > maxWidth, currentX > 0 {
+                currentX = 0
+                currentY += lineHeight + spacing
+                lineHeight = 0
+            }
+
+            positions.append(CGPoint(x: currentX, y: currentY))
+            lineHeight = max(lineHeight, size.height)
+            currentX += size.width + spacing
+            totalHeight = currentY + lineHeight
+        }
+
+        return (CGSize(width: maxWidth, height: totalHeight), positions)
+    }
+}
+
+#Preview {
+    ProjectDetailView(projectPath: "/Users/test/project")
+        .frame(width: 700, height: 500)
+}

--- a/Fig/Sources/Views/SidebarView.swift
+++ b/Fig/Sources/Views/SidebarView.swift
@@ -1,24 +1,465 @@
 import SwiftUI
 
-/// The sidebar view displaying navigation items.
+// MARK: - SidebarView
+
+/// The sidebar view displaying navigation items and projects.
 struct SidebarView: View {
-    @Binding var selectedItem: SidebarItem?
+    // MARK: Internal
+
+    @Binding var selection: NavigationSelection?
+    @Bindable var viewModel: ProjectExplorerViewModel
 
     var body: some View {
-        List(selection: $selectedItem) {
-            Section("Navigation") {
-                ForEach(SidebarItem.allCases) { item in
-                    Label(item.title, systemImage: item.icon)
-                        .tag(item)
+        List(selection: $selection) {
+            // Global Settings Section
+            Section("Configuration") {
+                Label("Global Settings", systemImage: "globe")
+                    .tag(NavigationSelection.globalSettings)
+            }
+
+            // Favorites Section
+            if !viewModel.favoriteProjects.isEmpty {
+                Section("Favorites") {
+                    ForEach(viewModel.favoriteProjects) { project in
+                        projectRow(for: project, isFavoriteSection: true)
+                    }
+                }
+            }
+
+            // Recents Section
+            if !viewModel.recentProjects.isEmpty {
+                Section("Recent") {
+                    ForEach(viewModel.recentProjects) { project in
+                        projectRow(for: project, isFavoriteSection: false)
+                    }
+                }
+            }
+
+            // All Projects Section
+            Section {
+                if viewModel.isLoading {
+                    HStack {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Loading projects...")
+                            .foregroundStyle(.secondary)
+                    }
+                } else if viewModel.filteredProjects.isEmpty, viewModel.favoriteProjects.isEmpty,
+                          viewModel.recentProjects.isEmpty
+                {
+                    if viewModel.searchQuery.isEmpty {
+                        ContentUnavailableView(
+                            "No Projects Found",
+                            systemImage: "folder.badge.questionmark",
+                            description: Text(
+                                "Claude Code projects will appear here once you use Claude Code in a directory."
+                            )
+                        )
+                    } else {
+                        ContentUnavailableView.search(text: viewModel.searchQuery)
+                    }
+                } else if viewModel.filteredProjects.isEmpty, !viewModel.searchQuery.isEmpty {
+                    ContentUnavailableView.search(text: viewModel.searchQuery)
+                } else {
+                    ForEach(viewModel.filteredProjects) { project in
+                        projectRow(for: project, isFavoriteSection: false)
+                    }
+                }
+            } header: {
+                HStack {
+                    Text("Projects")
+                    Spacer()
+                    if !viewModel.projects.isEmpty {
+                        Text("\(viewModel.filteredProjects.count)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(.quaternary, in: Capsule())
+                    }
                 }
             }
         }
         .listStyle(.sidebar)
+        .searchable(
+            text: $viewModel.searchQuery,
+            placement: .sidebar,
+            prompt: "Filter projects"
+        )
         .navigationTitle("Fig")
-        .frame(minWidth: 200)
+        .frame(minWidth: 220)
+        .task {
+            await viewModel.loadProjects()
+        }
+        .onChange(of: selection) { _, newValue in
+            // Record as recent when selecting a project
+            if case let .project(path) = newValue {
+                if let project = viewModel.projects.first(where: { $0.path == path }) {
+                    viewModel.recordRecentProject(project)
+                }
+            }
+        }
+        .sheet(isPresented: $viewModel.isQuickSwitcherPresented) {
+            QuickSwitcherView(viewModel: viewModel, selection: $selection)
+        }
+        .keyboardShortcut("k", modifiers: .command)
+    }
+
+    // MARK: Private
+
+    private func projectRow(for project: ProjectEntry, isFavoriteSection: Bool) -> some View {
+        ProjectRowView(
+            project: project,
+            exists: viewModel.projectExists(project),
+            mcpCount: viewModel.mcpServerCount(for: project),
+            isFavorite: viewModel.isFavorite(project)
+        )
+        .tag(NavigationSelection.project(project.path ?? ""))
+        .contextMenu {
+            Button {
+                viewModel.toggleFavorite(project)
+            } label: {
+                if viewModel.isFavorite(project) {
+                    Label("Remove from Favorites", systemImage: "star.slash")
+                } else {
+                    Label("Add to Favorites", systemImage: "star")
+                }
+            }
+
+            Divider()
+
+            Button {
+                viewModel.revealInFinder(project)
+            } label: {
+                Label("Reveal in Finder", systemImage: "folder")
+            }
+            .disabled(!viewModel.projectExists(project))
+
+            Button {
+                viewModel.openInTerminal(project)
+            } label: {
+                Label("Open in Terminal", systemImage: "terminal")
+            }
+            .disabled(!viewModel.projectExists(project))
+        }
+    }
+}
+
+// MARK: - ProjectRowView
+
+/// A row in the sidebar representing a single project.
+struct ProjectRowView: View {
+    // MARK: Internal
+
+    let project: ProjectEntry
+    let exists: Bool
+    let mcpCount: Int
+    var isFavorite: Bool = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            // Project icon with status
+            Image(systemName: exists ? "folder.fill" : "folder.badge.questionmark")
+                .foregroundStyle(exists ? .blue : .orange)
+                .frame(width: 20)
+
+            // Project info
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 4) {
+                    Text(project.name ?? "Unknown")
+                        .font(.body)
+                        .foregroundStyle(exists ? .primary : .secondary)
+                        .lineLimit(1)
+
+                    if isFavorite {
+                        Image(systemName: "star.fill")
+                            .foregroundStyle(.yellow)
+                            .font(.caption2)
+                    }
+                }
+
+                if let path = project.path {
+                    Text(abbreviatePath(path))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+
+            Spacer()
+
+            // MCP server badge
+            if mcpCount > 0 {
+                Text("\(mcpCount)")
+                    .font(.caption2)
+                    .fontWeight(.medium)
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(.purple, in: Capsule())
+                    .help("\(mcpCount) MCP server\(mcpCount == 1 ? "" : "s") configured")
+            }
+
+            // Missing indicator
+            if !exists {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.caption)
+                    .help("Project directory not found")
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    // MARK: Private
+
+    /// Abbreviates a path by replacing the home directory with ~.
+    private func abbreviatePath(_ path: String) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        if path.hasPrefix(home) {
+            return "~" + path.dropFirst(home.count)
+        }
+        return path
+    }
+}
+
+// MARK: - QuickSwitcherView
+
+/// A quick switcher sheet for rapidly navigating to projects.
+struct QuickSwitcherView: View {
+    // MARK: Internal
+
+    @Bindable var viewModel: ProjectExplorerViewModel
+    @Binding var selection: NavigationSelection?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Search field
+            HStack {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+
+                TextField("Search projects...", text: $searchText)
+                    .textFieldStyle(.plain)
+                    .font(.title3)
+                    .onSubmit {
+                        selectFirstResult()
+                    }
+
+                if !searchText.isEmpty {
+                    Button {
+                        searchText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding()
+
+            Divider()
+
+            // Results list
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(filteredResults.enumerated()), id: \.element.id) { index, project in
+                        QuickSwitcherRow(
+                            project: project,
+                            isSelected: index == selectedIndex,
+                            isFavorite: viewModel.isFavorite(project)
+                        )
+                        .onTapGesture {
+                            selectProject(project)
+                        }
+                    }
+
+                    if filteredResults.isEmpty {
+                        Text("No projects found")
+                            .foregroundStyle(.secondary)
+                            .padding()
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+            }
+            .frame(maxHeight: 300)
+
+            Divider()
+
+            // Keyboard hints
+            HStack {
+                KeyboardHint(key: "↑↓", label: "Navigate")
+                KeyboardHint(key: "↵", label: "Open")
+                KeyboardHint(key: "esc", label: "Close")
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+            .background(.quaternary.opacity(0.5))
+        }
+        .frame(width: 500)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .onAppear {
+            searchText = ""
+            selectedIndex = 0
+        }
+        .onKeyPress(.upArrow) {
+            if selectedIndex > 0 {
+                selectedIndex -= 1
+            }
+            return .handled
+        }
+        .onKeyPress(.downArrow) {
+            if selectedIndex < filteredResults.count - 1 {
+                selectedIndex += 1
+            }
+            return .handled
+        }
+        .onKeyPress(.return) {
+            selectFirstResult()
+            return .handled
+        }
+        .onKeyPress(.escape) {
+            viewModel.isQuickSwitcherPresented = false
+            return .handled
+        }
+    }
+
+    // MARK: Private
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var searchText = ""
+    @State private var selectedIndex = 0
+
+    private var filteredResults: [ProjectEntry] {
+        if searchText.isEmpty {
+            // Show favorites first, then recents, then all
+            let favorites = viewModel.favoriteProjects
+            let recents = viewModel.recentProjects
+            let others = viewModel.projects.filter { project in
+                guard let path = project.path else {
+                    return true
+                }
+                return !viewModel.favoritesStorage.favoriteProjectPaths.contains(path) &&
+                    !viewModel.favoritesStorage.recentProjectPaths.contains(path)
+            }
+            return favorites + recents + others
+        }
+        let query = searchText.lowercased()
+        return viewModel.projects.filter { project in
+            let nameMatch = project.name?.lowercased().contains(query) ?? false
+            let pathMatch = project.path?.lowercased().contains(query) ?? false
+            return nameMatch || pathMatch
+        }
+    }
+
+    private func selectFirstResult() {
+        guard !filteredResults.isEmpty else {
+            return
+        }
+        let project = filteredResults[min(selectedIndex, filteredResults.count - 1)]
+        selectProject(project)
+    }
+
+    private func selectProject(_ project: ProjectEntry) {
+        if let path = project.path {
+            selection = .project(path)
+            viewModel.recordRecentProject(project)
+        }
+        viewModel.isQuickSwitcherPresented = false
+    }
+}
+
+// MARK: - QuickSwitcherRow
+
+/// A row in the quick switcher results.
+struct QuickSwitcherRow: View {
+    // MARK: Internal
+
+    let project: ProjectEntry
+    let isSelected: Bool
+    let isFavorite: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "folder.fill")
+                .foregroundStyle(.blue)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 4) {
+                    Text(project.name ?? "Unknown")
+                        .font(.body)
+
+                    if isFavorite {
+                        Image(systemName: "star.fill")
+                            .foregroundStyle(.yellow)
+                            .font(.caption2)
+                    }
+                }
+
+                if let path = project.path {
+                    Text(abbreviatePath(path))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(isSelected ? Color.accentColor.opacity(0.2) : Color.clear)
+    }
+
+    // MARK: Private
+
+    private func abbreviatePath(_ path: String) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        if path.hasPrefix(home) {
+            return "~" + path.dropFirst(home.count)
+        }
+        return path
+    }
+}
+
+// MARK: - KeyboardHint
+
+/// A small keyboard hint label.
+struct KeyboardHint: View {
+    let key: String
+    let label: String
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Text(key)
+                .font(.caption)
+                .fontWeight(.medium)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(.quaternary, in: RoundedRectangle(cornerRadius: 4))
+
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
     }
 }
 
 #Preview {
-    SidebarView(selectedItem: .constant(.home))
+    let viewModel = ProjectExplorerViewModel()
+    return NavigationSplitView {
+        SidebarView(
+            selection: .constant(.globalSettings),
+            viewModel: viewModel
+        )
+    } detail: {
+        Text("Detail View")
+    }
+}
+
+#Preview("Quick Switcher") {
+    let viewModel = ProjectExplorerViewModel()
+    return QuickSwitcherView(viewModel: viewModel, selection: .constant(nil))
+        .padding()
 }


### PR DESCRIPTION
## Summary
- Implements the project explorer epic with sidebar navigation showing Configuration, Favorites, Recent, and All Projects sections
- Adds tabbed project detail view displaying Permissions, Environment, MCP Servers, Hooks, and Advanced settings with source attribution
- Implements favorites/recents persistence via UserDefaults and Quick Switcher (⌘K) for fast project navigation

## Test plan
- [ ] Verify sidebar displays projects from `~/.claude.json`
- [ ] Test project search filtering in sidebar
- [ ] Verify context menu actions (Add/Remove Favorites, Reveal in Finder, Open in Terminal)
- [ ] Test Quick Switcher opens with ⌘K and allows project selection
- [ ] Verify project detail tabs display correct configuration with source badges
- [ ] Test favorites and recent projects persist across app restarts
- [ ] Run `swift test` to verify all 48 tests pass

Closes #7, closes #8, closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)