### PR TITLE
feat: add project deletion from sidebar

### DIFF
--- a/Fig/Sources/ViewModels/ProjectExplorerViewModel.swift
+++ b/Fig/Sources/ViewModels/ProjectExplorerViewModel.swift
@@ -241,10 +241,13 @@ final class ProjectExplorerViewModel {
         NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: url.path)
     }
 
-    /// Deletes a project from the global configuration.
+    /// Removes a project from the global configuration.
     ///
     /// This removes the project entry from `~/.claude.json` and cleans up
     /// favorites and recents. The project directory itself is not affected.
+    ///
+    /// - Note: Callers are responsible for clearing any active selection
+    ///   referencing this project before invoking this method.
     func deleteProject(_ project: ProjectEntry) async {
         guard let path = project.path else {
             return
@@ -264,9 +267,9 @@ final class ProjectExplorerViewModel {
                 "Project removed",
                 message: "'\(project.name ?? path)' removed from configuration"
             )
-            Log.general.info("Deleted project from config: \(path)")
+            Log.general.info("Removed project from config: \(path)")
         } catch {
-            Log.general.error("Failed to delete project: \(error.localizedDescription)")
+            Log.general.error("Failed to remove project: \(error.localizedDescription)")
             NotificationManager.shared.showError(error)
         }
     }

--- a/Fig/Sources/Views/SidebarView.swift
+++ b/Fig/Sources/Views/SidebarView.swift
@@ -104,12 +104,12 @@ struct SidebarView: View {
         }
         .keyboardShortcut("k", modifiers: .command)
         .alert(
-            "Delete Project",
+            "Remove Project",
             isPresented: self.$showDeleteConfirmation,
             presenting: self.projectToDelete
         ) { project in
             Button("Cancel", role: .cancel) {}
-            Button("Delete", role: .destructive) {
+            Button("Remove", role: .destructive) {
                 Task {
                     if case let .project(path) = self.selection, path == project.path {
                         self.selection = nil
@@ -172,7 +172,7 @@ struct SidebarView: View {
                 self.projectToDelete = project
                 self.showDeleteConfirmation = true
             } label: {
-                Label("Delete Project", systemImage: "trash")
+                Label("Remove Project", systemImage: "trash")
             }
         }
     }


### PR DESCRIPTION
Add the ability to delete projects from the sidebar context menu. Users can now right-click any project and select "Delete Project" to remove it from ~/.claude.json with a confirmation dialog.

The deletion operation:
- Removes the project entry from the global configuration
- Cleans up favorites and recents for that project
- Does not affect the actual project directory
- Resets the navigation selection if the deleted project was currently selected