### PR TITLE
feat: add bulk project deletion with select mode

### DIFF
--- a/Fig/Sources/ViewModels/ProjectExplorerViewModel.swift
+++ b/Fig/Sources/ViewModels/ProjectExplorerViewModel.swift
@@ -298,8 +298,9 @@ final class ProjectExplorerViewModel {
 
             try await configManager.writeGlobalConfig(config)
 
+            let pathSet = Set(paths)
+            self.projects.removeAll { pathSet.contains($0.path ?? "") }
             for path in paths {
-                self.projects.removeAll { $0.path == path }
                 self.favoritesStorage.removeProject(path)
             }
 


### PR DESCRIPTION
Implements multi-select deletion for projects via a "Select" toolbar button. When active, checkboxes appear on each project row across all sections. A bottom action bar provides "Select All" and a "Remove" button for batch operations.

The batch deletion performs a single config read/write cycle for efficiency. After confirmation, select mode exits automatically and selections clear.

Follows standard macOS multi-select patterns used in Finder and Mail.