### PR TITLE
feat: implement Lua plugin system with built-in health checks

### DIFF
--- a/Fig/Package.swift
+++ b/Fig/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -18,12 +18,14 @@ let package = Package(
         .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.58.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.55.0"),
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.4.0"),
+        .package(url: "https://github.com/SwiftyLua/SwiftyLua", from: "0.0.2"),
     ],
     targets: [
         .executableTarget(
             name: "Fig",
             dependencies: [
                 .product(name: "MarkdownUI", package: "swift-markdown-ui"),
+                .product(name: "SwiftyLua", package: "SwiftyLua"),
             ],
             path: "Sources",
             swiftSettings: [

--- a/Fig/Package.swift
+++ b/Fig/Package.swift
@@ -28,6 +28,9 @@ let package = Package(
                 .product(name: "SwiftyLua", package: "SwiftyLua"),
             ],
             path: "Sources",
+            resources: [
+                .copy("../Resources/Plugins"),
+            ],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency"),
             ],

--- a/Fig/Resources/Plugins/builtin-good-practices/init.lua
+++ b/Fig/Resources/Plugins/builtin-good-practices/init.lua
@@ -1,0 +1,76 @@
+-- Built-in Good Practices Health Checks
+-- Reports good practices already in place (positive reinforcement)
+
+fig.health.registerCheck("GoodPractices", function(context)
+    local findings = {}
+    local denyRules = context.denyRules or {}
+    local allowRules = context.allowRules or {}
+
+    -- Check for .env in deny list
+    for _, rule in ipairs(denyRules) do
+        if string.find(rule, ".env", 1, true) then
+            table.insert(findings, fig.health.finding({
+                severity = fig.health.severity.INFO,
+                title = "Sensitive files protected",
+                description = "Your deny list includes rules to protect .env files from being read."
+            }))
+            break
+        end
+    end
+
+    -- Check for secrets in deny list
+    for _, rule in ipairs(denyRules) do
+        if string.find(rule, "secrets", 1, true) then
+            table.insert(findings, fig.health.finding({
+                severity = fig.health.severity.INFO,
+                title = "Secrets directory protected",
+                description = "Your deny list includes rules to protect the secrets directory."
+            }))
+            break
+        end
+    end
+
+    -- Check for local settings
+    if context.localSettingsExists then
+        table.insert(findings, fig.health.finding({
+            severity = fig.health.severity.INFO,
+            title = "Local settings configured",
+            description = "You have a settings.local.json for personal overrides."
+        }))
+    end
+
+    -- Check for project MCP config
+    if context.mcpConfigExists then
+        table.insert(findings, fig.health.finding({
+            severity = fig.health.severity.INFO,
+            title = "Project-scoped MCP servers",
+            description = "MCP servers are configured at the project level for better isolation."
+        }))
+    end
+
+    -- Check for hooks
+    if context.hasHooks then
+        table.insert(findings, fig.health.finding({
+            severity = fig.health.severity.INFO,
+            title = "Hooks configured",
+            description = "Lifecycle hooks are set up for automated workflows."
+        }))
+    end
+
+    -- Check for scoped permissions
+    for _, rule in ipairs(allowRules) do
+        -- Rules with specific paths or patterns are considered scoped
+        if string.find(rule, "/", 1, true) or string.find(rule, "**", 1, true) then
+            table.insert(findings, fig.health.finding({
+                severity = fig.health.severity.INFO,
+                title = "Scoped permission rules",
+                description = "Permission rules use specific path patterns for fine-grained access control."
+            }))
+            break
+        end
+    end
+
+    return findings
+end)
+
+fig.log.info("Good practices health checks registered")

--- a/Fig/Resources/Plugins/builtin-good-practices/plugin.json
+++ b/Fig/Resources/Plugins/builtin-good-practices/plugin.json
@@ -1,0 +1,19 @@
+{
+  "id": "com.fig.builtin.good-practices",
+  "name": "Good Practices",
+  "version": "1.0.0",
+  "author": {
+    "name": "Fig Team",
+    "email": "fig@anthropic.com"
+  },
+  "summary": "Reports good practices already in place",
+  "description": "Provides positive feedback about good configuration practices you've already implemented, such as protecting sensitive files and using project-scoped settings.",
+  "category": "health-checks",
+  "main": "init.lua",
+  "capabilities": [
+    "health:register",
+    "health:findings",
+    "config:read:global",
+    "config:read:project"
+  ]
+}

--- a/Fig/Resources/Plugins/builtin-security/init.lua
+++ b/Fig/Resources/Plugins/builtin-security/init.lua
@@ -1,0 +1,175 @@
+-- Built-in Security Health Checks
+-- Checks for common security issues in Claude Code configuration
+
+-- Deny List Security Check
+-- Ensures sensitive files like .env and secrets/ are in the deny list
+fig.health.registerCheck("DenyListSecurity", function(context)
+    local findings = {}
+    local denyRules = context.denyRules or {}
+
+    -- Check for .env files
+    local hasEnvDeny = false
+    for _, rule in ipairs(denyRules) do
+        if string.find(rule, ".env", 1, true) then
+            hasEnvDeny = true
+            break
+        end
+    end
+
+    if not hasEnvDeny then
+        table.insert(findings, fig.health.finding({
+            severity = fig.health.severity.CRITICAL,
+            title = ".env files not in deny list",
+            description = "Environment files often contain secrets like API keys and passwords. Add a deny rule to prevent Claude from reading them.",
+            autoFix = fig.health.autoFix.addRule("Read(.env)")
+        }))
+    end
+
+    -- Check for secrets/ directory
+    local hasSecretsDeny = false
+    for _, rule in ipairs(denyRules) do
+        if string.find(rule, "secrets", 1, true) then
+            hasSecretsDeny = true
+            break
+        end
+    end
+
+    if not hasSecretsDeny then
+        table.insert(findings, fig.health.finding({
+            severity = fig.health.severity.CRITICAL,
+            title = "secrets/ directory not in deny list",
+            description = "The secrets/ directory may contain sensitive credentials. Add a deny rule to prevent Claude from accessing it.",
+            autoFix = fig.health.autoFix.addRule("Read(secrets/**)")
+        }))
+    end
+
+    return findings
+end)
+
+-- Broad Allow Rules Check
+-- Checks for overly broad allow rules that may pose security risks
+fig.health.registerCheck("BroadAllowRules", function(context)
+    local findings = {}
+    local allowRules = context.allowRules or {}
+
+    local broadPatterns = {
+        { pattern = "Bash(*)", description = "Allows any Bash command without restriction" },
+        { pattern = "Read(*)", description = "Allows reading any file without restriction" },
+        { pattern = "Write(*)", description = "Allows writing to any file without restriction" },
+        { pattern = "Edit(*)", description = "Allows editing any file without restriction" }
+    }
+
+    for _, broad in ipairs(broadPatterns) do
+        for _, rule in ipairs(allowRules) do
+            if rule == broad.pattern then
+                table.insert(findings, fig.health.finding({
+                    severity = fig.health.severity.WARNING,
+                    title = "Overly broad allow rule: " .. broad.pattern,
+                    description = broad.description .. ". Consider using more specific patterns to limit what Claude can access."
+                }))
+                break
+            end
+        end
+    end
+
+    return findings
+end)
+
+-- MCP Hardcoded Secrets Check
+-- Checks for MCP servers with hardcoded secrets in their configuration
+fig.health.registerCheck("MCPHardcodedSecrets", function(context)
+    local findings = {}
+    local mcpServers = context.mcpServers or {}
+
+    -- Patterns that suggest a value is a secret
+    local secretPrefixes = {
+        "sk-", "sk_", "ghp_", "gho_", "ghu_", "ghs_",
+        "xoxb-", "xoxp-", "xoxs-",
+        "AKIA", "Bearer ",
+        "-----BEGIN"
+    }
+
+    -- Environment variable names that commonly hold secrets
+    local secretKeyNames = {
+        "TOKEN", "SECRET", "KEY", "PASSWORD", "CREDENTIAL",
+        "AUTH", "API_KEY", "APIKEY", "PRIVATE"
+    }
+
+    local function looksLikeSecret(key, value)
+        local upperKey = string.upper(key)
+
+        -- Check if the key name suggests it's a secret
+        local keyIsSecret = false
+        for _, secretName in ipairs(secretKeyNames) do
+            if string.find(upperKey, secretName, 1, true) then
+                keyIsSecret = true
+                break
+            end
+        end
+
+        -- Check if the value looks like a known secret format
+        local valueIsSecret = false
+        for _, prefix in ipairs(secretPrefixes) do
+            if string.sub(value, 1, #prefix) == prefix then
+                valueIsSecret = true
+                break
+            end
+        end
+
+        -- A short value is unlikely to be a secret
+        local isLongEnough = #value >= 8
+
+        return (keyIsSecret and isLongEnough) or valueIsSecret
+    end
+
+    for name, server in pairs(mcpServers) do
+        -- Check env vars for hardcoded secrets
+        if server.env then
+            for key, value in pairs(server.env) do
+                if type(value) == "string" and looksLikeSecret(key, value) then
+                    table.insert(findings, fig.health.finding({
+                        severity = fig.health.severity.WARNING,
+                        title = "Hardcoded secret in MCP server '" .. name .. "'",
+                        description = "The environment variable '" .. key .. "' appears to contain a hardcoded secret. Consider using environment variable references instead."
+                    }))
+                end
+            end
+        end
+
+        -- Check HTTP headers for hardcoded secrets
+        if server.headers then
+            for key, value in pairs(server.headers) do
+                if type(value) == "string" and looksLikeSecret(key, value) then
+                    table.insert(findings, fig.health.finding({
+                        severity = fig.health.severity.WARNING,
+                        title = "Hardcoded secret in MCP server '" .. name .. "' headers",
+                        description = "The header '" .. key .. "' appears to contain a hardcoded secret. Consider using environment variable references instead."
+                    }))
+                end
+            end
+        end
+    end
+
+    return findings
+end)
+
+-- Global Config Size Check
+-- Checks if the global config file is too large (performance issue)
+fig.health.registerCheck("GlobalConfigSize", function(context)
+    local findings = {}
+    local sizeBytes = context.globalConfigFileSize or 0
+    local sizeThreshold = 5 * 1024 * 1024 -- 5 MB
+
+    if sizeBytes > sizeThreshold then
+        local megabytes = sizeBytes / (1024 * 1024)
+        table.insert(findings, fig.health.finding({
+            severity = fig.health.severity.WARNING,
+            title = string.format("~/.claude.json is large (%.1f MB)", megabytes),
+            description = "A large global config file can slow down Claude Code startup. Consider cleaning up old project entries or conversation history."
+        }))
+    end
+
+    return findings
+end)
+
+fig.log.info("Security health checks registered")

--- a/Fig/Resources/Plugins/builtin-security/plugin.json
+++ b/Fig/Resources/Plugins/builtin-security/plugin.json
@@ -1,0 +1,19 @@
+{
+  "id": "com.fig.builtin.security",
+  "name": "Security Checks",
+  "version": "1.0.0",
+  "author": {
+    "name": "Fig Team",
+    "email": "fig@anthropic.com"
+  },
+  "summary": "Built-in security health checks for Claude Code configuration",
+  "description": "Checks for common security issues in your Claude Code configuration, including missing deny list entries for sensitive files, overly broad allow rules, and hardcoded secrets in MCP server configurations.",
+  "category": "health-checks",
+  "main": "init.lua",
+  "capabilities": [
+    "health:register",
+    "health:findings",
+    "config:read:global",
+    "config:read:project"
+  ]
+}

--- a/Fig/Resources/Plugins/builtin-suggestions/init.lua
+++ b/Fig/Resources/Plugins/builtin-suggestions/init.lua
@@ -1,0 +1,56 @@
+-- Built-in Configuration Suggestion Health Checks
+-- Provides helpful suggestions for improving Claude Code configuration
+
+-- Local Settings Check
+-- Suggests creating settings.local.json for personal overrides
+fig.health.registerCheck("LocalSettings", function(context)
+    local findings = {}
+
+    if not context.localSettingsExists then
+        table.insert(findings, fig.health.finding({
+            severity = fig.health.severity.SUGGESTION,
+            title = "No settings.local.json",
+            description = "Create a local settings file for personal overrides that won't be committed to version control. This is useful for developer-specific environment variables or permission tweaks.",
+            autoFix = fig.health.autoFix.createLocalSettings()
+        }))
+    end
+
+    return findings
+end)
+
+-- MCP Scoping Check
+-- Suggests creating a project .mcp.json when global MCP servers exist
+fig.health.registerCheck("MCPScoping", function(context)
+    local findings = {}
+    local hasGlobalServers = context.hasGlobalMCPServers or false
+    local hasProjectMCP = context.mcpConfigExists or false
+
+    if hasGlobalServers and not hasProjectMCP then
+        table.insert(findings, fig.health.finding({
+            severity = fig.health.severity.SUGGESTION,
+            title = "Global MCP servers without project scoping",
+            description = "You have global MCP servers configured but no project-level .mcp.json. Consider creating a project-scoped MCP configuration for better isolation."
+        }))
+    end
+
+    return findings
+end)
+
+-- Hook Suggestions Check
+-- Suggests hooks for common development patterns
+fig.health.registerCheck("HookSuggestions", function(context)
+    local findings = {}
+    local hasAnyHooks = context.hasHooks or false
+
+    if not hasAnyHooks then
+        table.insert(findings, fig.health.finding({
+            severity = fig.health.severity.SUGGESTION,
+            title = "No hooks configured",
+            description = "Hooks let you run commands before or after Claude uses tools. Common uses include running formatters after file edits or linters before committing code."
+        }))
+    end
+
+    return findings
+end)
+
+fig.log.info("Suggestion health checks registered")

--- a/Fig/Resources/Plugins/builtin-suggestions/plugin.json
+++ b/Fig/Resources/Plugins/builtin-suggestions/plugin.json
@@ -1,0 +1,19 @@
+{
+  "id": "com.fig.builtin.suggestions",
+  "name": "Configuration Suggestions",
+  "version": "1.0.0",
+  "author": {
+    "name": "Fig Team",
+    "email": "fig@anthropic.com"
+  },
+  "summary": "Built-in health checks that suggest configuration improvements",
+  "description": "Provides helpful suggestions for improving your Claude Code configuration, such as creating local settings files and scoping MCP servers to projects.",
+  "category": "health-checks",
+  "main": "init.lua",
+  "capabilities": [
+    "health:register",
+    "health:findings",
+    "config:read:global",
+    "config:read:project"
+  ]
+}

--- a/Fig/Sources/App/FigApp.swift
+++ b/Fig/Sources/App/FigApp.swift
@@ -12,6 +12,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
             NSApp.activate(ignoringOtherApps: true)
             NSApp.windows.first?.makeKeyAndOrderFront(nil)
         }
+
+        // Initialize the plugin system
+        Task {
+            await LuaPluginService.shared.initialize()
+        }
     }
 }
 

--- a/Fig/Sources/App/FigApp.swift
+++ b/Fig/Sources/App/FigApp.swift
@@ -1,6 +1,8 @@
 import AppKit
 import SwiftUI
 
+// MARK: - AppDelegate
+
 /// App delegate to configure the application before UI loads.
 final class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
     func applicationDidFinishLaunching(_: Notification) {
@@ -12,6 +14,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
         }
     }
 }
+
+// MARK: - FigApp
 
 /// The main entry point for the Fig application.
 @main

--- a/Fig/Sources/App/FocusedValues.swift
+++ b/Fig/Sources/App/FocusedValues.swift
@@ -1,21 +1,27 @@
 import SwiftUI
 
-// MARK: - Focused Value Keys
+// MARK: - NavigationSelectionKey
 
 /// Key for the navigation selection binding.
 private struct NavigationSelectionKey: FocusedValueKey {
     typealias Value = Binding<NavigationSelection?>
 }
 
+// MARK: - ProjectDetailTabKey
+
 /// Key for the project detail tab binding.
 private struct ProjectDetailTabKey: FocusedValueKey {
     typealias Value = Binding<ProjectDetailTab>
 }
 
+// MARK: - GlobalSettingsTabKey
+
 /// Key for the global settings tab binding.
 private struct GlobalSettingsTabKey: FocusedValueKey {
     typealias Value = Binding<GlobalSettingsTab>
 }
+
+// MARK: - AddMCPServerActionKey
 
 /// Key for the add MCP server action.
 private struct AddMCPServerActionKey: FocusedValueKey {

--- a/Fig/Sources/Models/ConfigBundle.swift
+++ b/Fig/Sources/Models/ConfigBundle.swift
@@ -65,13 +65,13 @@ struct ConfigBundle: Codable, Equatable {
 
     /// Whether the bundle has any content.
     var isEmpty: Bool {
-        settings == nil && localSettings == nil && mcpServers == nil
+        self.settings == nil && self.localSettings == nil && self.mcpServers == nil
     }
 
     /// Whether the bundle contains potentially sensitive data.
     var containsSensitiveData: Bool {
         // Check local settings (usually contains sensitive data)
-        if localSettings != nil {
+        if self.localSettings != nil {
             return true
         }
 
@@ -151,7 +151,11 @@ enum ConfigBundleComponent: String, CaseIterable, Identifiable {
     case localSettings
     case mcpServers
 
-    var id: String { rawValue }
+    // MARK: Internal
+
+    var id: String {
+        rawValue
+    }
 
     var displayName: String {
         switch self {
@@ -189,17 +193,16 @@ enum ConfigBundleComponent: String, CaseIterable, Identifiable {
 
 /// Represents a conflict found during import.
 struct ImportConflict: Identifiable {
-    let id = UUID()
-    let component: ConfigBundleComponent
-    let description: String
-    var resolution: ImportResolution = .merge
-
     enum ImportResolution: String, CaseIterable, Identifiable {
-        case merge    // Combine with existing (for arrays/dicts)
-        case replace  // Replace existing completely
-        case skip     // Keep existing, skip import
+        case merge // Combine with existing (for arrays/dicts)
+        case replace // Replace existing completely
+        case skip // Keep existing, skip import
 
-        var id: String { rawValue }
+        // MARK: Internal
+
+        var id: String {
+            rawValue
+        }
 
         var displayName: String {
             switch self {
@@ -209,6 +212,11 @@ struct ImportConflict: Identifiable {
             }
         }
     }
+
+    let id = UUID()
+    let component: ConfigBundleComponent
+    let description: String
+    var resolution: ImportResolution = .merge
 }
 
 // MARK: - ImportResult

--- a/Fig/Sources/Models/Finding.swift
+++ b/Fig/Sources/Models/Finding.swift
@@ -91,6 +91,23 @@ enum AutoFix: Sendable, Equatable {
 
 /// A single finding from a health check.
 struct Finding: Identifiable, Sendable {
+    // MARK: Lifecycle
+
+    init(
+        severity: Severity,
+        title: String,
+        description: String,
+        autoFix: AutoFix? = nil
+    ) {
+        self.id = UUID()
+        self.severity = severity
+        self.title = title
+        self.description = description
+        self.autoFix = autoFix
+    }
+
+    // MARK: Internal
+
     /// Unique identifier for this finding.
     let id: UUID
 
@@ -105,19 +122,6 @@ struct Finding: Identifiable, Sendable {
 
     /// Optional auto-fix action for this finding.
     let autoFix: AutoFix?
-
-    init(
-        severity: Severity,
-        title: String,
-        description: String,
-        autoFix: AutoFix? = nil
-    ) {
-        self.id = UUID()
-        self.severity = severity
-        self.title = title
-        self.description = description
-        self.autoFix = autoFix
-    }
 }
 
 // MARK: - HealthCheckContext

--- a/Fig/Sources/Models/Plugins/PluginCapability.swift
+++ b/Fig/Sources/Models/Plugins/PluginCapability.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+// MARK: - PluginCapability
+
+/// Capabilities that plugins can request.
+///
+/// The plugin system uses capability-based permissions rather than broad access grants.
+/// Plugins must declare required capabilities in their manifest, and sensitive capabilities
+/// require explicit user approval before the plugin can be loaded.
+///
+/// Capability strings follow a hierarchical format: `category:action:scope`
+/// - `config:read:global` - Read global settings
+/// - `health:register` - Register health checks
+/// - `fs:read:project` - Read files in project directory
+public enum PluginCapability: String, CaseIterable, Codable, Sendable {
+    // MARK: - Configuration Access
+
+    /// Read global settings (~/.claude/settings.json).
+    case configReadGlobal = "config:read:global"
+
+    /// Read project-level settings (.claude/settings.json).
+    case configReadProject = "config:read:project"
+
+    /// Read MCP server configurations.
+    case configReadMCP = "config:read:mcp"
+
+    /// Write to project settings (.claude/settings.json).
+    case configWriteProject = "config:write:project"
+
+    /// Write to local settings (.claude/settings.local.json).
+    case configWriteLocal = "config:write:local"
+
+    // MARK: - Health Check System
+
+    /// Register new health checks.
+    case healthRegister = "health:register"
+
+    /// Create health check findings.
+    case healthFindings = "health:findings"
+
+    /// Provide auto-fix actions for findings.
+    case healthAutofix = "health:autofix"
+
+    // MARK: - Preset Contribution
+
+    /// Register permission rule presets.
+    case presetRegister = "preset:register"
+
+    /// Register MCP server templates.
+    case mcpTemplateRegister = "mcp:template:register"
+
+    /// Register hook templates.
+    case hookTemplateRegister = "hook:template:register"
+
+    // MARK: - Event System
+
+    /// Subscribe to lifecycle events.
+    case eventSubscribe = "event:subscribe"
+
+    // MARK: - User Interface
+
+    /// Show notifications to the user.
+    case uiNotification = "ui:notification"
+
+    // MARK: - Filesystem (Sandboxed)
+
+    /// Read files within the project directory.
+    case fsReadProject = "fs:read:project"
+
+    /// Check if files exist.
+    case fsExists = "fs:exists"
+
+    // MARK: Public
+
+    /// Whether this capability is considered sensitive and requires explicit user approval.
+    public var isSensitive: Bool {
+        switch self {
+        case .configWriteProject,
+             .configWriteLocal,
+             .healthAutofix,
+             .fsReadProject:
+            true
+        default:
+            false
+        }
+    }
+
+    /// Human-readable description of what this capability allows.
+    public var localizedDescription: String {
+        switch self {
+        case .configReadGlobal:
+            "Read global Claude Code settings"
+        case .configReadProject:
+            "Read project-level settings"
+        case .configReadMCP:
+            "Read MCP server configurations"
+        case .configWriteProject:
+            "Modify project settings"
+        case .configWriteLocal:
+            "Modify local settings (not committed to git)"
+        case .healthRegister:
+            "Register custom health checks"
+        case .healthFindings:
+            "Report health check findings"
+        case .healthAutofix:
+            "Provide automatic fixes for issues"
+        case .presetRegister:
+            "Register permission presets"
+        case .mcpTemplateRegister:
+            "Register MCP server templates"
+        case .hookTemplateRegister:
+            "Register hook templates"
+        case .eventSubscribe:
+            "Listen to lifecycle events"
+        case .uiNotification:
+            "Show notifications"
+        case .fsReadProject:
+            "Read files in the project directory"
+        case .fsExists:
+            "Check if files exist"
+        }
+    }
+
+    /// Icon name (SF Symbol) for this capability category.
+    public var iconName: String {
+        switch self {
+        case .configReadGlobal,
+             .configReadProject,
+             .configReadMCP,
+             .configWriteProject,
+             .configWriteLocal:
+            "gearshape"
+        case .healthRegister,
+             .healthFindings,
+             .healthAutofix:
+            "heart.text.square"
+        case .presetRegister,
+             .mcpTemplateRegister,
+             .hookTemplateRegister:
+            "square.grid.2x2"
+        case .eventSubscribe:
+            "bell"
+        case .uiNotification:
+            "bubble.left"
+        case .fsReadProject,
+             .fsExists:
+            "folder"
+        }
+    }
+
+    // MARK: Internal
+
+    /// Parse a capability string into a PluginCapability.
+    /// Returns nil if the string doesn't match a known capability.
+    static func from(string: String) -> PluginCapability? {
+        PluginCapability(rawValue: string)
+    }
+
+    /// Parse an array of capability strings, ignoring unknown capabilities.
+    static func parse(capabilities: [String]?) -> Set<PluginCapability> {
+        guard let capabilities else {
+            return []
+        }
+        return Set(capabilities.compactMap { PluginCapability.from(string: $0) })
+    }
+}
+
+// MARK: Comparable
+
+extension PluginCapability: Comparable {
+    public static func < (lhs: PluginCapability, rhs: PluginCapability) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}

--- a/Fig/Sources/Models/Plugins/PluginError.swift
+++ b/Fig/Sources/Models/Plugins/PluginError.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+// MARK: - PluginError
+
+/// Errors specific to the Lua plugin system.
+public enum PluginError: Error, LocalizedError, Sendable, Equatable {
+    /// Plugin was not found at the expected location.
+    case pluginNotFound(id: String)
+
+    /// Plugin manifest is missing from the plugin directory.
+    case manifestMissing(path: String)
+
+    /// Plugin manifest is invalid or cannot be parsed.
+    case manifestInvalid(path: String, reason: String)
+
+    /// Plugin failed to load.
+    case loadFailed(id: String, reason: String)
+
+    /// Plugin execution failed.
+    case executionFailed(id: String, function: String, reason: String)
+
+    /// Plugin attempted an unauthorized operation.
+    case securityViolation(reason: String)
+
+    /// Required Lua function was not found in the plugin.
+    case functionNotFound(name: String)
+
+    /// Plugin requested a capability that was not granted.
+    case permissionDenied(capability: String)
+
+    /// Plugin execution timed out.
+    case timeout(id: String, function: String)
+
+    /// Lua runtime error.
+    case luaError(message: String)
+
+    /// Plugin version is incompatible with the current Fig version.
+    case versionIncompatible(pluginId: String, required: String, current: String)
+
+    /// Plugin depends on another plugin that is not installed.
+    case dependencyMissing(pluginId: String, dependencyId: String)
+
+    /// Plugin is already loaded.
+    case alreadyLoaded(id: String)
+
+    /// Plugin installation failed.
+    case installFailed(reason: String)
+
+    /// Plugin uninstallation failed.
+    case uninstallFailed(id: String, reason: String)
+
+    /// Checksum verification failed.
+    case checksumMismatch(expected: String, actual: String)
+
+    /// Signature verification failed.
+    case signatureInvalid(reason: String)
+
+    /// Network error during plugin operations.
+    case networkError(reason: String)
+
+    // MARK: Public
+
+    public var errorDescription: String? {
+        switch self {
+        case let .pluginNotFound(id):
+            "Plugin not found: \(id)"
+        case let .manifestMissing(path):
+            "Plugin manifest (plugin.json) not found at: \(path)"
+        case let .manifestInvalid(path, reason):
+            "Invalid plugin manifest at \(path): \(reason)"
+        case let .loadFailed(id, reason):
+            "Failed to load plugin '\(id)': \(reason)"
+        case let .executionFailed(id, function, reason):
+            "Plugin '\(id)' function '\(function)' failed: \(reason)"
+        case let .securityViolation(reason):
+            "Security violation: \(reason)"
+        case let .functionNotFound(name):
+            "Lua function not found: \(name)"
+        case let .permissionDenied(capability):
+            "Permission denied: plugin requires '\(capability)' capability"
+        case let .timeout(id, function):
+            "Plugin '\(id)' function '\(function)' timed out"
+        case let .luaError(message):
+            "Lua error: \(message)"
+        case let .versionIncompatible(pluginId, required, current):
+            "Plugin '\(pluginId)' requires Fig version \(required), but current version is \(current)"
+        case let .dependencyMissing(pluginId, dependencyId):
+            "Plugin '\(pluginId)' requires plugin '\(dependencyId)' which is not installed"
+        case let .alreadyLoaded(id):
+            "Plugin '\(id)' is already loaded"
+        case let .installFailed(reason):
+            "Plugin installation failed: \(reason)"
+        case let .uninstallFailed(id, reason):
+            "Failed to uninstall plugin '\(id)': \(reason)"
+        case let .checksumMismatch(expected, actual):
+            "Checksum verification failed: expected \(expected), got \(actual)"
+        case let .signatureInvalid(reason):
+            "Signature verification failed: \(reason)"
+        case let .networkError(reason):
+            "Network error: \(reason)"
+        }
+    }
+
+    public var recoverySuggestion: String? {
+        switch self {
+        case .pluginNotFound:
+            "Ensure the plugin is installed in ~/.fig/plugins/"
+        case .manifestMissing:
+            "Each plugin directory must contain a plugin.json manifest file"
+        case .manifestInvalid:
+            "Check the plugin's plugin.json file for syntax errors or missing required fields"
+        case .loadFailed:
+            "Check the plugin's Lua code for syntax errors"
+        case .executionFailed:
+            "Review the plugin's error handling and contact the plugin author"
+        case .securityViolation:
+            "The plugin attempted an operation it doesn't have permission for"
+        case .functionNotFound:
+            "Ensure the plugin exports the required function in its main Lua file"
+        case .permissionDenied:
+            "Grant the required capability to the plugin in Fig's settings"
+        case .timeout:
+            "The plugin is taking too long to execute. Check for infinite loops"
+        case .luaError:
+            "Check the plugin's Lua code for errors"
+        case .versionIncompatible:
+            "Update Fig to a compatible version or find an older version of the plugin"
+        case .dependencyMissing:
+            "Install the required dependency plugin first"
+        case .alreadyLoaded:
+            "The plugin is already running. Reload it if you want to apply changes"
+        case .installFailed:
+            "Check your network connection and try again"
+        case .uninstallFailed:
+            "Close any files the plugin may be using and try again"
+        case .checksumMismatch:
+            "The downloaded file may be corrupted. Try downloading again"
+        case .signatureInvalid:
+            "Only install plugins from trusted sources"
+        case .networkError:
+            "Check your internet connection and try again"
+        }
+    }
+
+    public var failureReason: String? {
+        self.errorDescription
+    }
+}

--- a/Fig/Sources/Models/Plugins/PluginManifest.swift
+++ b/Fig/Sources/Models/Plugins/PluginManifest.swift
@@ -1,0 +1,321 @@
+import Foundation
+
+// MARK: - PluginManifest
+
+/// Metadata describing a Lua plugin and its capabilities.
+///
+/// Plugin manifests are stored in `plugin.json` at the root of each plugin directory.
+/// The manifest defines the plugin's identity, entry point, hooks, and required permissions.
+///
+/// Example JSON:
+/// ```json
+/// {
+///   "id": "com.example.my-plugin",
+///   "name": "My Plugin",
+///   "version": "1.0.0",
+///   "author": { "name": "Author Name" },
+///   "summary": "A brief description",
+///   "main": "init.lua",
+///   "category": "health-checks"
+/// }
+/// ```
+public struct PluginManifest: Codable, Equatable, Hashable, Sendable {
+    // MARK: Lifecycle
+
+    public init(
+        id: String,
+        name: String,
+        version: String,
+        author: PluginAuthor,
+        summary: String,
+        description: String? = nil,
+        category: PluginCategory = .other,
+        main: String = "init.lua",
+        hooks: [PluginHookRegistration]? = nil,
+        permissions: PluginPermissions? = nil,
+        capabilities: [String]? = nil,
+        minFigVersion: String? = nil,
+        homepage: String? = nil,
+        repository: String? = nil,
+        license: String? = nil,
+        additionalProperties: [String: AnyCodable]? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.version = version
+        self.author = author
+        self.summary = summary
+        self.description = description
+        self.category = category
+        self.main = main
+        self.hooks = hooks
+        self.permissions = permissions
+        self.capabilities = capabilities
+        self.minFigVersion = minFigVersion
+        self.homepage = homepage
+        self.repository = repository
+        self.license = license
+        self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.version = try container.decode(String.self, forKey: .version)
+        self.author = try container.decode(PluginAuthor.self, forKey: .author)
+        self.summary = try container.decode(String.self, forKey: .summary)
+        self.description = try container.decodeIfPresent(String.self, forKey: .description)
+        self.category = try container.decodeIfPresent(PluginCategory.self, forKey: .category) ?? .other
+        self.main = try container.decodeIfPresent(String.self, forKey: .main) ?? "init.lua"
+        self.hooks = try container.decodeIfPresent([PluginHookRegistration].self, forKey: .hooks)
+        self.permissions = try container.decodeIfPresent(PluginPermissions.self, forKey: .permissions)
+        self.capabilities = try container.decodeIfPresent([String].self, forKey: .capabilities)
+        self.minFigVersion = try container.decodeIfPresent(String.self, forKey: .minFigVersion)
+        self.homepage = try container.decodeIfPresent(String.self, forKey: .homepage)
+        self.repository = try container.decodeIfPresent(String.self, forKey: .repository)
+        self.license = try container.decodeIfPresent(String.self, forKey: .license)
+
+        // Capture unknown keys
+        let allKeysContainer = try decoder.container(keyedBy: DynamicCodingKey.self)
+        var additional: [String: AnyCodable] = [:]
+
+        for key in allKeysContainer.allKeys where !Self.knownKeys.contains(key.stringValue) {
+            additional[key.stringValue] = try allKeysContainer.decode(AnyCodable.self, forKey: key)
+        }
+
+        self.additionalProperties = additional.isEmpty ? nil : additional
+    }
+
+    // MARK: Public
+
+    /// Unique plugin identifier (reverse-domain style, e.g., "com.author.plugin-name").
+    public let id: String
+
+    /// Human-readable plugin name.
+    public let name: String
+
+    /// Plugin version using semantic versioning (e.g., "1.2.3").
+    public let version: String
+
+    /// Plugin author information.
+    public let author: PluginAuthor
+
+    /// Short description of the plugin (max 140 characters recommended).
+    public let summary: String
+
+    /// Full description of the plugin (Markdown supported).
+    public let description: String?
+
+    /// Plugin category for marketplace organization.
+    public let category: PluginCategory
+
+    /// Main Lua entry point (relative to plugin directory).
+    public let main: String
+
+    /// Hooks this plugin wants to register for.
+    public let hooks: [PluginHookRegistration]?
+
+    /// Permissions the plugin requests (deprecated, use capabilities).
+    public let permissions: PluginPermissions?
+
+    /// Capabilities the plugin requests (e.g., "config:read", "health:register").
+    public let capabilities: [String]?
+
+    /// Minimum Fig version required.
+    public let minFigVersion: String?
+
+    /// Plugin homepage URL.
+    public let homepage: String?
+
+    /// Plugin source repository URL.
+    public let repository: String?
+
+    /// License identifier (SPDX format, e.g., "MIT").
+    public let license: String?
+
+    /// Additional properties for forward compatibility.
+    public var additionalProperties: [String: AnyCodable]?
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.name, forKey: .name)
+        try container.encode(self.version, forKey: .version)
+        try container.encode(self.author, forKey: .author)
+        try container.encode(self.summary, forKey: .summary)
+        try container.encodeIfPresent(self.description, forKey: .description)
+        try container.encode(self.category, forKey: .category)
+        try container.encode(self.main, forKey: .main)
+        try container.encodeIfPresent(self.hooks, forKey: .hooks)
+        try container.encodeIfPresent(self.permissions, forKey: .permissions)
+        try container.encodeIfPresent(self.capabilities, forKey: .capabilities)
+        try container.encodeIfPresent(self.minFigVersion, forKey: .minFigVersion)
+        try container.encodeIfPresent(self.homepage, forKey: .homepage)
+        try container.encodeIfPresent(self.repository, forKey: .repository)
+        try container.encodeIfPresent(self.license, forKey: .license)
+
+        // Encode additional properties
+        if let additionalProperties {
+            var additionalContainer = encoder.container(keyedBy: DynamicCodingKey.self)
+            for (key, value) in additionalProperties {
+                try additionalContainer.encode(value, forKey: DynamicCodingKey(stringValue: key))
+            }
+        }
+    }
+
+    // MARK: Private
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case version
+        case author
+        case summary
+        case description
+        case category
+        case main
+        case hooks
+        case permissions
+        case capabilities
+        case minFigVersion
+        case homepage
+        case repository
+        case license
+    }
+
+    private static let knownKeys: Set<String> = [
+        "id", "name", "version", "author", "summary", "description",
+        "category", "main", "hooks", "permissions", "capabilities",
+        "minFigVersion", "homepage", "repository", "license",
+    ]
+}
+
+// MARK: - PluginAuthor
+
+/// Information about a plugin's author.
+public struct PluginAuthor: Codable, Equatable, Hashable, Sendable {
+    // MARK: Lifecycle
+
+    public init(
+        name: String,
+        email: String? = nil,
+        url: String? = nil
+    ) {
+        self.name = name
+        self.email = email
+        self.url = url
+    }
+
+    // MARK: Public
+
+    /// Author's display name.
+    public let name: String
+
+    /// Author's email address (optional).
+    public let email: String?
+
+    /// Author's website URL (optional).
+    public let url: String?
+}
+
+// MARK: - PluginCategory
+
+/// Categories for organizing plugins in the marketplace.
+public enum PluginCategory: String, CaseIterable, Sendable {
+    case healthChecks = "health-checks"
+    case permissions
+    case mcpServers = "mcp-servers"
+    case hooks
+    case templates
+    case workflows
+    case integrations
+    case other
+}
+
+// MARK: Codable
+
+extension PluginCategory: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        // Fall back to .other for unknown categories (forward compatibility)
+        self = PluginCategory(rawValue: rawValue) ?? .other
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+// MARK: - PluginHookRegistration
+
+/// A hook registration declared in the plugin manifest.
+public struct PluginHookRegistration: Codable, Equatable, Hashable, Sendable {
+    // MARK: Lifecycle
+
+    public init(
+        event: String,
+        handler: String,
+        matcher: String? = nil,
+        priority: Int? = nil
+    ) {
+        self.event = event
+        self.handler = handler
+        self.matcher = matcher
+        self.priority = priority
+    }
+
+    // MARK: Public
+
+    /// Hook event type (e.g., "PreToolUse", "PostToolUse").
+    public let event: String
+
+    /// Lua function name to call when the hook fires.
+    public let handler: String
+
+    /// Optional glob pattern to match against tool names (e.g., "Write(*.py)").
+    public let matcher: String?
+
+    /// Execution priority (lower values run first, default is 1000).
+    public let priority: Int?
+}
+
+// MARK: - PluginPermissions
+
+/// Legacy permissions structure (deprecated, use capabilities).
+public struct PluginPermissions: Codable, Equatable, Hashable, Sendable {
+    // MARK: Lifecycle
+
+    public init(
+        fileRead: Bool? = nil,
+        fileWrite: Bool? = nil,
+        network: Bool? = nil,
+        environment: Bool? = nil,
+        shell: Bool? = nil
+    ) {
+        self.fileRead = fileRead
+        self.fileWrite = fileWrite
+        self.network = network
+        self.environment = environment
+        self.shell = shell
+    }
+
+    // MARK: Public
+
+    /// Can read files (within sandbox).
+    public let fileRead: Bool?
+
+    /// Can write files (within sandbox).
+    public let fileWrite: Bool?
+
+    /// Can make HTTP requests.
+    public let network: Bool?
+
+    /// Can access environment variables.
+    public let environment: Bool?
+
+    /// Can execute shell commands (restricted).
+    public let shell: Bool?
+}

--- a/Fig/Sources/Models/Plugins/PluginState.swift
+++ b/Fig/Sources/Models/Plugins/PluginState.swift
@@ -1,0 +1,315 @@
+import Foundation
+
+// MARK: - PluginLifecycleState
+
+/// Lifecycle state of a plugin.
+public enum PluginLifecycleState: String, Codable, Sendable {
+    /// Plugin has been discovered but not loaded.
+    case discovered
+
+    /// Plugin is currently being loaded.
+    case loading
+
+    /// Plugin has been loaded and initialized successfully.
+    case active
+
+    /// Plugin encountered an error during loading or execution.
+    case error
+
+    /// Plugin has been disabled by the user.
+    case disabled
+
+    /// Plugin is being unloaded.
+    case unloading
+}
+
+// MARK: - LoadedPlugin
+
+/// Runtime representation of a loaded plugin.
+public struct LoadedPlugin: Sendable, Identifiable {
+    // MARK: Lifecycle
+
+    public init(
+        manifest: PluginManifest,
+        path: URL,
+        state: PluginLifecycleState = .discovered,
+        error: PluginError? = nil,
+        config: [String: AnyCodable] = [:],
+        loadedAt: Date? = nil,
+        grantedCapabilities: Set<PluginCapability> = []
+    ) {
+        self.manifest = manifest
+        self.path = path
+        self.state = state
+        self.error = error
+        self.config = config
+        self.loadedAt = loadedAt
+        self.grantedCapabilities = grantedCapabilities
+    }
+
+    // MARK: Public
+
+    /// The plugin's manifest.
+    public let manifest: PluginManifest
+
+    /// Path to the plugin directory.
+    public let path: URL
+
+    /// Current lifecycle state.
+    public var state: PluginLifecycleState
+
+    /// Error if the plugin is in error state.
+    public var error: PluginError?
+
+    /// Plugin-specific configuration values.
+    public var config: [String: AnyCodable]
+
+    /// When the plugin was last loaded.
+    public var loadedAt: Date?
+
+    /// Capabilities that have been granted to this plugin.
+    public var grantedCapabilities: Set<PluginCapability>
+
+    public var id: String {
+        self.manifest.id
+    }
+
+    /// Whether the plugin is currently active and can execute.
+    public var isActive: Bool {
+        self.state == .active
+    }
+
+    /// Capabilities requested by the plugin that haven't been granted.
+    public var pendingCapabilities: Set<PluginCapability> {
+        let requested = PluginCapability.parse(capabilities: self.manifest.capabilities)
+        return requested.subtracting(self.grantedCapabilities)
+    }
+
+    /// Whether the plugin has all requested capabilities.
+    public var hasAllCapabilities: Bool {
+        self.pendingCapabilities.isEmpty
+    }
+}
+
+// MARK: - PluginInstallationState
+
+/// Persistent state tracking all installed plugins.
+public struct PluginInstallationState: Codable, Equatable, Sendable {
+    // MARK: Lifecycle
+
+    public init(
+        version: Int = Self.currentVersion,
+        plugins: [String: InstalledPluginInfo] = [:],
+        disabledPlugins: Set<String> = [],
+        grantedCapabilities: [String: Set<String>] = [:]
+    ) {
+        self.version = version
+        self.plugins = plugins
+        self.disabledPlugins = disabledPlugins
+        self.grantedCapabilities = grantedCapabilities
+    }
+
+    // MARK: Public
+
+    /// Current state file format version.
+    public static let currentVersion = 1
+
+    /// State file format version.
+    public let version: Int
+
+    /// Installed plugins keyed by plugin ID.
+    public var plugins: [String: InstalledPluginInfo]
+
+    /// Plugin IDs that have been disabled by the user.
+    public var disabledPlugins: Set<String>
+
+    /// Capabilities granted to each plugin, keyed by plugin ID.
+    /// Values are raw capability strings for forward compatibility.
+    public var grantedCapabilities: [String: Set<String>]
+
+    /// Check if a plugin is disabled.
+    public func isDisabled(_ pluginId: String) -> Bool {
+        self.disabledPlugins.contains(pluginId)
+    }
+
+    /// Get granted capabilities for a plugin.
+    public func capabilities(for pluginId: String) -> Set<PluginCapability> {
+        guard let granted = grantedCapabilities[pluginId] else {
+            return []
+        }
+        return PluginCapability.parse(capabilities: Array(granted))
+    }
+}
+
+// MARK: - InstalledPluginInfo
+
+/// Persistent information about an installed plugin.
+public struct InstalledPluginInfo: Codable, Equatable, Hashable, Sendable {
+    // MARK: Lifecycle
+
+    public init(
+        pluginId: String,
+        version: String,
+        installedAt: Date,
+        installPath: String,
+        source: PluginSource
+    ) {
+        self.pluginId = pluginId
+        self.version = version
+        self.installedAt = installedAt
+        self.installPath = installPath
+        self.source = source
+    }
+
+    // MARK: Public
+
+    /// Plugin identifier.
+    public let pluginId: String
+
+    /// Installed version.
+    public let version: String
+
+    /// When the plugin was installed.
+    public let installedAt: Date
+
+    /// Path where the plugin is installed (relative to plugin root).
+    public let installPath: String
+
+    /// Where the plugin came from.
+    public let source: PluginSource
+}
+
+// MARK: - PluginSource
+
+/// Source from which a plugin was installed.
+public enum PluginSource: Codable, Equatable, Hashable, Sendable {
+    /// Built-in plugin bundled with Fig.
+    case builtin
+
+    /// Installed from the Farmer's Market registry.
+    case marketplace(registryId: String)
+
+    /// Installed from a local .figplugin file.
+    case local(originalPath: String)
+
+    /// Installed from a URL.
+    case url(String)
+}
+
+// MARK: - PluginHookResult
+
+/// Result of executing a plugin hook.
+public struct PluginHookResult: Sendable {
+    // MARK: Lifecycle
+
+    public init(
+        pluginId: String,
+        hookEvent: String,
+        success: Bool,
+        output: [String: AnyCodable]? = nil,
+        error: String? = nil,
+        duration: TimeInterval = 0
+    ) {
+        self.pluginId = pluginId
+        self.hookEvent = hookEvent
+        self.success = success
+        self.output = output
+        self.error = error
+        self.duration = duration
+    }
+
+    // MARK: Public
+
+    /// ID of the plugin that executed the hook.
+    public let pluginId: String
+
+    /// The hook event that was handled.
+    public let hookEvent: String
+
+    /// Whether the hook executed successfully.
+    public let success: Bool
+
+    /// Output data from the hook (if any).
+    public let output: [String: AnyCodable]?
+
+    /// Error message if the hook failed.
+    public let error: String?
+
+    /// How long the hook took to execute.
+    public let duration: TimeInterval
+}
+
+// MARK: - HookExecutionContext
+
+/// Context passed to plugin hooks during execution.
+public struct HookExecutionContext: Sendable {
+    // MARK: Lifecycle
+
+    public init(
+        event: String,
+        toolName: String? = nil,
+        toolInput: String? = nil,
+        toolOutput: String? = nil,
+        projectPath: URL? = nil,
+        filePath: String? = nil,
+        additionalData: [String: AnyCodable] = [:]
+    ) {
+        self.event = event
+        self.toolName = toolName
+        self.toolInput = toolInput
+        self.toolOutput = toolOutput
+        self.projectPath = projectPath
+        self.filePath = filePath
+        self.additionalData = additionalData
+    }
+
+    // MARK: Public
+
+    /// The hook event type (e.g., "PreToolUse", "PostToolUse").
+    public let event: String
+
+    /// Tool name for tool-related hooks (e.g., "Bash", "Write").
+    public let toolName: String?
+
+    /// Tool input for tool-related hooks.
+    public let toolInput: String?
+
+    /// Tool output for PostToolUse hooks.
+    public let toolOutput: String?
+
+    /// Current project path.
+    public let projectPath: URL?
+
+    /// Affected file path (for Write, Edit hooks).
+    public let filePath: String?
+
+    /// Additional context data.
+    public let additionalData: [String: AnyCodable]
+
+    /// Convert to a dictionary for passing to Lua.
+    public func toDictionary() -> [String: Any] {
+        var dict: [String: Any] = ["event": event]
+
+        if let toolName {
+            dict["toolName"] = toolName
+        }
+        if let toolInput {
+            dict["toolInput"] = toolInput
+        }
+        if let toolOutput {
+            dict["toolOutput"] = toolOutput
+        }
+        if let projectPath {
+            dict["projectPath"] = projectPath.path
+        }
+        if let filePath {
+            dict["filePath"] = filePath
+        }
+
+        for (key, value) in self.additionalData {
+            dict[key] = value.value
+        }
+
+        return dict
+    }
+}

--- a/Fig/Sources/Models/SettingsEditorTypes.swift
+++ b/Fig/Sources/Models/SettingsEditorTypes.swift
@@ -4,41 +4,44 @@ import Foundation
 
 /// A permission rule with editing metadata.
 struct EditablePermissionRule: Identifiable, Equatable, Hashable {
-    let id: UUID
-    var rule: String
-    var type: PermissionType
+    // MARK: Lifecycle
 
     init(id: UUID = UUID(), rule: String, type: PermissionType) {
         self.id = id
         self.rule = rule
         self.type = type
     }
+
+    // MARK: Internal
+
+    let id: UUID
+    var rule: String
+    var type: PermissionType
 }
 
 // MARK: - EditableEnvironmentVariable
 
 /// An environment variable with editing metadata.
 struct EditableEnvironmentVariable: Identifiable, Equatable, Hashable {
-    let id: UUID
-    var key: String
-    var value: String
+    // MARK: Lifecycle
 
     init(id: UUID = UUID(), key: String, value: String) {
         self.id = id
         self.key = key
         self.value = value
     }
+
+    // MARK: Internal
+
+    let id: UUID
+    var key: String
+    var value: String
 }
 
 // MARK: - KnownEnvironmentVariable
 
 /// Known Claude Code environment variables with descriptions.
 struct KnownEnvironmentVariable: Identifiable {
-    let id: String
-    let name: String
-    let description: String
-    let defaultValue: String?
-
     static let allVariables: [KnownEnvironmentVariable] = [
         KnownEnvironmentVariable(
             id: "CLAUDE_CODE_MAX_OUTPUT_TOKENS",
@@ -99,11 +102,16 @@ struct KnownEnvironmentVariable: Identifiable {
             name: "ANTHROPIC_DEFAULT_HAIKU_MODEL",
             description: "Default Haiku model to use",
             defaultValue: nil
-        )
+        ),
     ]
 
+    let id: String
+    let name: String
+    let description: String
+    let defaultValue: String?
+
     static func description(for key: String) -> String? {
-        allVariables.first { $0.name == key }?.description
+        self.allVariables.first { $0.name == key }?.description
     }
 }
 
@@ -111,11 +119,6 @@ struct KnownEnvironmentVariable: Identifiable {
 
 /// Quick-add presets for common permission patterns.
 struct PermissionPreset: Identifiable {
-    let id: String
-    let name: String
-    let description: String
-    let rules: [(rule: String, type: PermissionType)]
-
     static let allPresets: [PermissionPreset] = [
         PermissionPreset(
             id: "protect-env",
@@ -123,7 +126,7 @@ struct PermissionPreset: Identifiable {
             description: "Prevent reading environment files",
             rules: [
                 ("Read(.env)", .deny),
-                ("Read(.env.*)", .deny)
+                ("Read(.env.*)", .deny),
             ]
         ),
         PermissionPreset(
@@ -131,7 +134,7 @@ struct PermissionPreset: Identifiable {
             name: "Allow npm scripts",
             description: "Allow running npm scripts",
             rules: [
-                ("Bash(npm run *)", .allow)
+                ("Bash(npm run *)", .allow),
             ]
         ),
         PermissionPreset(
@@ -139,7 +142,7 @@ struct PermissionPreset: Identifiable {
             name: "Allow git operations",
             description: "Allow running git commands",
             rules: [
-                ("Bash(git *)", .allow)
+                ("Bash(git *)", .allow),
             ]
         ),
         PermissionPreset(
@@ -148,7 +151,7 @@ struct PermissionPreset: Identifiable {
             description: "Deny all write and edit operations",
             rules: [
                 ("Write", .deny),
-                ("Edit", .deny)
+                ("Edit", .deny),
             ]
         ),
         PermissionPreset(
@@ -156,7 +159,7 @@ struct PermissionPreset: Identifiable {
             name: "Allow reading source",
             description: "Allow reading all files in src directory",
             rules: [
-                ("Read(src/**)", .allow)
+                ("Read(src/**)", .allow),
             ]
         ),
         PermissionPreset(
@@ -164,10 +167,15 @@ struct PermissionPreset: Identifiable {
             name: "Block curl commands",
             description: "Prevent curl network requests",
             rules: [
-                ("Bash(curl *)", .deny)
+                ("Bash(curl *)", .deny),
             ]
-        )
+        ),
     ]
+
+    let id: String
+    let name: String
+    let description: String
+    let rules: [(rule: String, type: PermissionType)]
 }
 
 // MARK: - ToolType
@@ -184,7 +192,11 @@ enum ToolType: String, CaseIterable, Identifiable {
     case notebook = "Notebook"
     case custom = "Custom"
 
-    var id: String { rawValue }
+    // MARK: Internal
+
+    var id: String {
+        rawValue
+    }
 
     var placeholder: String {
         switch self {
@@ -222,7 +234,16 @@ enum EditingTarget: String, CaseIterable, Identifiable {
     case projectShared
     case projectLocal
 
-    var id: String { rawValue }
+    // MARK: Internal
+
+    /// Targets available when editing project settings.
+    static var projectTargets: [EditingTarget] {
+        [.projectShared, .projectLocal]
+    }
+
+    var id: String {
+        rawValue
+    }
 
     var label: String {
         switch self {
@@ -256,21 +277,13 @@ enum EditingTarget: String, CaseIterable, Identifiable {
             .projectLocal
         }
     }
-
-    /// Targets available when editing project settings.
-    static var projectTargets: [EditingTarget] {
-        [.projectShared, .projectLocal]
-    }
 }
 
 // MARK: - EditableHookDefinition
 
 /// A hook definition with editing metadata.
 struct EditableHookDefinition: Identifiable, Equatable, Hashable {
-    let id: UUID
-    var type: String
-    var command: String
-    var additionalProperties: [String: AnyCodable]?
+    // MARK: Lifecycle
 
     init(id: UUID = UUID(), type: String = "command", command: String = "") {
         self.id = id
@@ -286,11 +299,18 @@ struct EditableHookDefinition: Identifiable, Equatable, Hashable {
         self.additionalProperties = definition.additionalProperties
     }
 
+    // MARK: Internal
+
+    let id: UUID
+    var type: String
+    var command: String
+    var additionalProperties: [String: AnyCodable]?
+
     func toHookDefinition() -> HookDefinition {
         HookDefinition(
-            type: type,
-            command: command.isEmpty ? nil : command,
-            additionalProperties: additionalProperties
+            type: self.type,
+            command: self.command.isEmpty ? nil : self.command,
+            additionalProperties: self.additionalProperties
         )
     }
 }
@@ -299,10 +319,7 @@ struct EditableHookDefinition: Identifiable, Equatable, Hashable {
 
 /// A hook group with editing metadata.
 struct EditableHookGroup: Identifiable, Equatable, Hashable {
-    let id: UUID
-    var matcher: String
-    var hooks: [EditableHookDefinition]
-    var additionalProperties: [String: AnyCodable]?
+    // MARK: Lifecycle
 
     init(id: UUID = UUID(), matcher: String = "", hooks: [EditableHookDefinition] = []) {
         self.id = id
@@ -318,11 +335,18 @@ struct EditableHookGroup: Identifiable, Equatable, Hashable {
         self.additionalProperties = group.additionalProperties
     }
 
+    // MARK: Internal
+
+    let id: UUID
+    var matcher: String
+    var hooks: [EditableHookDefinition]
+    var additionalProperties: [String: AnyCodable]?
+
     func toHookGroup() -> HookGroup {
         HookGroup(
-            matcher: matcher.isEmpty ? nil : matcher,
-            hooks: hooks.isEmpty ? nil : hooks.map { $0.toHookDefinition() },
-            additionalProperties: additionalProperties
+            matcher: self.matcher.isEmpty ? nil : self.matcher,
+            hooks: self.hooks.isEmpty ? nil : self.hooks.map { $0.toHookDefinition() },
+            additionalProperties: self.additionalProperties
         )
     }
 }
@@ -338,7 +362,9 @@ enum HookEvent: String, CaseIterable, Identifiable {
 
     // MARK: Internal
 
-    var id: String { rawValue }
+    var id: String {
+        rawValue
+    }
 
     var displayName: String {
         switch self {
@@ -378,8 +404,10 @@ enum HookEvent: String, CaseIterable, Identifiable {
 
     var supportsMatcher: Bool {
         switch self {
-        case .preToolUse, .postToolUse: true
-        case .notification, .stop: false
+        case .preToolUse,
+             .postToolUse: true
+        case .notification,
+             .stop: false
         }
     }
 }
@@ -388,13 +416,6 @@ enum HookEvent: String, CaseIterable, Identifiable {
 
 /// Quick-add templates for common hook configurations.
 struct HookTemplate: Identifiable {
-    let id: String
-    let name: String
-    let description: String
-    let event: HookEvent
-    let matcher: String?
-    let commands: [String]
-
     static let allTemplates: [HookTemplate] = [
         HookTemplate(
             id: "format-python",
@@ -447,6 +468,13 @@ struct HookTemplate: Identifiable {
             commands: ["swift-format format -i $CLAUDE_FILE_PATH"]
         ),
     ]
+
+    let id: String
+    let name: String
+    let description: String
+    let event: HookEvent
+    let matcher: String?
+    let commands: [String]
 }
 
 // MARK: - ConflictResolution

--- a/Fig/Sources/Services/ConfigFileManager.swift
+++ b/Fig/Sources/Services/ConfigFileManager.swift
@@ -216,7 +216,7 @@ actor ConfigFileManager {
 
     /// Writes the global legacy config to ~/.claude.json.
     func writeGlobalConfig(_ config: LegacyConfig) async throws {
-        try await write(config, to: globalConfigURL)
+        try await self.write(config, to: self.globalConfigURL)
     }
 
     // MARK: - File Watching

--- a/Fig/Sources/Services/PermissionRuleCopyService.swift
+++ b/Fig/Sources/Services/PermissionRuleCopyService.swift
@@ -59,7 +59,7 @@ actor PermissionRuleCopyService {
 
         settings.permissions = permissions
 
-        try await writeSettings(
+        try await self.writeSettings(
             settings,
             for: destination,
             projectPath: projectPath,
@@ -113,7 +113,7 @@ actor PermissionRuleCopyService {
             settings.permissions = permissions
         }
 
-        try await writeSettings(
+        try await self.writeSettings(
             settings,
             for: source,
             projectPath: projectPath,
@@ -136,12 +136,11 @@ actor PermissionRuleCopyService {
             projectPath: projectPath,
             configManager: configManager
         )
-        let existingRules: [String]
-        switch type {
+        let existingRules: [String] = switch type {
         case .allow:
-            existingRules = settings?.permissions?.allow ?? []
+            settings?.permissions?.allow ?? []
         case .deny:
-            existingRules = settings?.permissions?.deny ?? []
+            settings?.permissions?.deny ?? []
         }
         return existingRules.contains(rule)
     }

--- a/Fig/Sources/Services/Plugins/LuaFigAPI.swift
+++ b/Fig/Sources/Services/Plugins/LuaFigAPI.swift
@@ -142,6 +142,9 @@ public enum LuaFigAPI {
 
     // MARK: - Config Read API
 
+    // TODO: Implement actual config reading. These stubs currently just log requests.
+    // Implementation requires passing ConfigFileManager or config values into the API registration.
+
     private static func registerConfigReadAPI(
         sandbox: LuaSandbox,
         figTable: Table,
@@ -150,10 +153,10 @@ public enum LuaFigAPI {
         let configTable = (figTable["config"] as? Table) ?? sandbox.createTable()
 
         // fig.config.getGlobal(key) -> value
+        // TODO: Implement actual global config reading
         if capabilities.contains(.configReadGlobal) {
             let getGlobalFn = sandbox.vm.vm.createFunction([String.arg]) { args in
                 let key = args.string
-                // This would need to be async in practice - returning placeholder
                 Log.general.debug("Plugin requested global config key: \(key)")
                 return .nothing
             }
@@ -161,6 +164,7 @@ public enum LuaFigAPI {
         }
 
         // fig.config.getProject(key) -> value
+        // TODO: Implement actual project config reading
         if capabilities.contains(.configReadProject) {
             let getProjectFn = sandbox.vm.vm.createFunction([String.arg]) { args in
                 let key = args.string
@@ -175,6 +179,9 @@ public enum LuaFigAPI {
 
     // MARK: - Config Write API
 
+    // TODO: Implement actual config writing. These stubs currently just log requests.
+    // Implementation requires async coordination with ConfigFileManager.
+
     private static func registerConfigWriteAPI(
         sandbox: LuaSandbox,
         figTable: Table,
@@ -183,6 +190,7 @@ public enum LuaFigAPI {
         let configTable = (figTable["config"] as? Table) ?? sandbox.createTable()
 
         // fig.config.setProject(key, value)
+        // TODO: Implement actual project config writing
         if capabilities.contains(.configWriteProject) {
             let setProjectFn = sandbox.vm.vm.createFunction([String.arg]) { args in
                 let key = args.string
@@ -193,6 +201,7 @@ public enum LuaFigAPI {
         }
 
         // fig.config.setLocal(key, value)
+        // TODO: Implement actual local config writing
         if capabilities.contains(.configWriteLocal) {
             let setLocalFn = sandbox.vm.vm.createFunction([String.arg]) { args in
                 let key = args.string

--- a/Fig/Sources/Services/Plugins/LuaFigAPI.swift
+++ b/Fig/Sources/Services/Plugins/LuaFigAPI.swift
@@ -1,0 +1,372 @@
+import Foundation
+import lua4swift
+import OSLog
+
+// MARK: - LuaFigAPI
+
+/// Provides the `fig.*` API surface for Lua plugins.
+///
+/// This class registers Lua functions that allow plugins to interact with Fig's
+/// configuration, health check system, and other services. Functions are exposed
+/// based on the plugin's granted capabilities.
+///
+/// ## API Modules
+///
+/// | Module | Capabilities | Description |
+/// |--------|-------------|-------------|
+/// | `fig.log` | Always | Logging (debug, info, warning, error) |
+/// | `fig.config` | `config:read:*`, `config:write:*` | Read/write settings |
+/// | `fig.health` | `health:register`, `health:findings` | Register health checks |
+/// | `fig.preset` | `preset:register` | Register permission presets |
+/// | `fig.version` | Always | Fig version information |
+public enum LuaFigAPI {
+    // MARK: Public
+
+    /// Registers the Fig API modules with a Lua sandbox.
+    ///
+    /// - Parameters:
+    ///   - sandbox: The Lua sandbox to register APIs with
+    ///   - pluginId: The plugin's identifier (for logging and attribution)
+    ///   - registry: Optional registry to store plugin registrations
+    public static func register(
+        with sandbox: LuaSandbox,
+        pluginId: String,
+        registry: PluginAPIRegistry? = nil
+    ) {
+        // Create the main 'fig' table
+        let figTable = sandbox.createTable()
+        sandbox.setGlobal("fig", value: figTable)
+
+        // Always register version and log
+        self.registerVersionAPI(sandbox: sandbox, figTable: figTable)
+        self.registerLogAPI(sandbox: sandbox, figTable: figTable, pluginId: pluginId)
+
+        // Register capability-gated APIs
+        let capabilities = sandbox.capabilities
+
+        if capabilities.contains(.configReadGlobal) || capabilities.contains(.configReadProject) {
+            self.registerConfigReadAPI(sandbox: sandbox, figTable: figTable, capabilities: capabilities)
+        }
+
+        if capabilities.contains(.configWriteProject) || capabilities.contains(.configWriteLocal) {
+            self.registerConfigWriteAPI(sandbox: sandbox, figTable: figTable, capabilities: capabilities)
+        }
+
+        if capabilities.contains(.healthRegister) {
+            self.registerHealthAPI(
+                sandbox: sandbox,
+                figTable: figTable,
+                pluginId: pluginId,
+                registry: registry
+            )
+        }
+
+        if capabilities.contains(.presetRegister) {
+            self.registerPresetAPI(
+                sandbox: sandbox,
+                figTable: figTable,
+                pluginId: pluginId,
+                registry: registry
+            )
+        }
+
+        if capabilities.contains(.fsReadProject) || capabilities.contains(.fsExists) {
+            self.registerFilesystemAPI(sandbox: sandbox, figTable: figTable, capabilities: capabilities)
+        }
+    }
+
+    // MARK: Private
+
+    // MARK: - Version API
+
+    private static func registerVersionAPI(
+        sandbox: LuaSandbox,
+        figTable: Table
+    ) {
+        let versionTable = sandbox.createTable()
+
+        // Get app version from bundle
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+        let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+
+        versionTable["app"] = appVersion
+        versionTable["build"] = buildNumber
+        versionTable["api"] = "1.0" // Plugin API version
+
+        figTable["version"] = versionTable
+    }
+
+    // MARK: - Log API
+
+    private static func registerLogAPI(
+        sandbox: LuaSandbox,
+        figTable: Table,
+        pluginId: String
+    ) {
+        let logTable = sandbox.createTable()
+
+        // fig.log.debug(message)
+        let debugFn = sandbox.vm.vm.createFunction([String.arg]) { args in
+            let message = args.string
+            Log.general.debug("[\(pluginId)] \(message)")
+            return .nothing
+        }
+        logTable["debug"] = debugFn
+
+        // fig.log.info(message)
+        let infoFn = sandbox.vm.vm.createFunction([String.arg]) { args in
+            let message = args.string
+            Log.general.info("[\(pluginId)] \(message)")
+            return .nothing
+        }
+        logTable["info"] = infoFn
+
+        // fig.log.warning(message)
+        let warningFn = sandbox.vm.vm.createFunction([String.arg]) { args in
+            let message = args.string
+            Log.general.warning("[\(pluginId)] \(message)")
+            return .nothing
+        }
+        logTable["warning"] = warningFn
+
+        // fig.log.error(message)
+        let errorFn = sandbox.vm.vm.createFunction([String.arg]) { args in
+            let message = args.string
+            Log.general.error("[\(pluginId)] \(message)")
+            return .nothing
+        }
+        logTable["error"] = errorFn
+
+        figTable["log"] = logTable
+    }
+
+    // MARK: - Config Read API
+
+    private static func registerConfigReadAPI(
+        sandbox: LuaSandbox,
+        figTable: Table,
+        capabilities: Set<PluginCapability>
+    ) {
+        let configTable = (figTable["config"] as? Table) ?? sandbox.createTable()
+
+        // fig.config.getGlobal(key) -> value
+        if capabilities.contains(.configReadGlobal) {
+            let getGlobalFn = sandbox.vm.vm.createFunction([String.arg]) { args in
+                let key = args.string
+                // This would need to be async in practice - returning placeholder
+                Log.general.debug("Plugin requested global config key: \(key)")
+                return .nothing
+            }
+            configTable["getGlobal"] = getGlobalFn
+        }
+
+        // fig.config.getProject(key) -> value
+        if capabilities.contains(.configReadProject) {
+            let getProjectFn = sandbox.vm.vm.createFunction([String.arg]) { args in
+                let key = args.string
+                Log.general.debug("Plugin requested project config key: \(key)")
+                return .nothing
+            }
+            configTable["getProject"] = getProjectFn
+        }
+
+        figTable["config"] = configTable
+    }
+
+    // MARK: - Config Write API
+
+    private static func registerConfigWriteAPI(
+        sandbox: LuaSandbox,
+        figTable: Table,
+        capabilities: Set<PluginCapability>
+    ) {
+        let configTable = (figTable["config"] as? Table) ?? sandbox.createTable()
+
+        // fig.config.setProject(key, value)
+        if capabilities.contains(.configWriteProject) {
+            let setProjectFn = sandbox.vm.vm.createFunction([String.arg]) { args in
+                let key = args.string
+                Log.general.debug("Plugin setting project config key: \(key)")
+                return .nothing
+            }
+            configTable["setProject"] = setProjectFn
+        }
+
+        // fig.config.setLocal(key, value)
+        if capabilities.contains(.configWriteLocal) {
+            let setLocalFn = sandbox.vm.vm.createFunction([String.arg]) { args in
+                let key = args.string
+                Log.general.debug("Plugin setting local config key: \(key)")
+                return .nothing
+            }
+            configTable["setLocal"] = setLocalFn
+        }
+
+        figTable["config"] = configTable
+    }
+
+    // MARK: - Health API
+
+    private static func registerHealthAPI(
+        sandbox: LuaSandbox,
+        figTable: Table,
+        pluginId: String,
+        registry: PluginAPIRegistry?
+    ) {
+        let healthTable = sandbox.createTable()
+
+        // fig.health.registerCheck(id, checkFunction)
+        let registerCheckFn = sandbox.vm.vm.createFunction([String.arg, Function.arg]) { args in
+            let checkId = args.string
+            let checkFn = args.function
+
+            let fullId = "\(pluginId).\(checkId)"
+            registry?.registerHealthCheck(id: fullId, pluginId: pluginId, function: checkFn)
+
+            Log.general.info("Plugin \(pluginId) registered health check: \(checkId)")
+            return .nothing
+        }
+        healthTable["registerCheck"] = registerCheckFn
+
+        // fig.health.finding(options) -> finding table
+        let findingFn = sandbox.vm.vm.createFunction([Table.arg]) { args in
+            // Just pass through the table - it will be interpreted by the health check runner
+            let options = args.table
+            return .value(options)
+        }
+        healthTable["finding"] = findingFn
+
+        // fig.health.severity enum
+        let severityTable = sandbox.createTable()
+        severityTable["CRITICAL"] = "critical"
+        severityTable["WARNING"] = "warning"
+        severityTable["SUGGESTION"] = "suggestion"
+        severityTable["INFO"] = "info"
+        healthTable["severity"] = severityTable
+
+        // fig.health.autoFix helpers
+        let autoFixTable = sandbox.createTable()
+
+        // fig.health.autoFix.createLocalSettings()
+        let createLocalSettingsFn = sandbox.vm.vm.createFunction([]) { _ in
+            let fix = sandbox.createTable()
+            fix["type"] = "createLocalSettings"
+            return .value(fix)
+        }
+        autoFixTable["createLocalSettings"] = createLocalSettingsFn
+
+        // fig.health.autoFix.addRule(rule)
+        let addRuleFn = sandbox.vm.vm.createFunction([String.arg]) { args in
+            let rule = args.string
+            let fix = sandbox.createTable()
+            fix["type"] = "addRule"
+            fix["rule"] = rule
+            return .value(fix)
+        }
+        autoFixTable["addRule"] = addRuleFn
+
+        healthTable["autoFix"] = autoFixTable
+
+        figTable["health"] = healthTable
+    }
+
+    // MARK: - Preset API
+
+    private static func registerPresetAPI(
+        sandbox: LuaSandbox,
+        figTable: Table,
+        pluginId: String,
+        registry: PluginAPIRegistry?
+    ) {
+        let presetTable = sandbox.createTable()
+
+        // fig.preset.registerPermissionPreset(options)
+        let registerPresetFn = sandbox.vm.vm.createFunction([Table.arg]) { args in
+            let options = args.table
+
+            guard let presetId = options["id"] as? String else {
+                return .error("Preset must have an 'id' field")
+            }
+
+            let fullId = "\(pluginId).\(presetId)"
+            registry?.registerPreset(id: fullId, pluginId: pluginId, options: options)
+
+            Log.general.info("Plugin \(pluginId) registered preset: \(presetId)")
+            return .nothing
+        }
+        presetTable["registerPermissionPreset"] = registerPresetFn
+
+        figTable["preset"] = presetTable
+    }
+
+    // MARK: - Filesystem API
+
+    private static func registerFilesystemAPI(
+        sandbox: LuaSandbox,
+        figTable: Table,
+        capabilities: Set<PluginCapability>
+    ) {
+        let fsTable = sandbox.createTable()
+
+        // fig.fs.exists(path) -> boolean
+        if capabilities.contains(.fsExists) {
+            let existsFn = sandbox.vm.vm.createFunction([String.arg]) { args in
+                let path = args.string
+
+                // Only allow checking within plugin directory for safety
+                let fullPath = sandbox.pluginPath.appendingPathComponent(path)
+                let resolvedPath = fullPath.standardizedFileURL.path
+                let pluginBasePath = sandbox.pluginPath.standardizedFileURL.path
+
+                guard resolvedPath.hasPrefix(pluginBasePath) else {
+                    Log.general.warning("Plugin attempted to check file outside sandbox: \(path)")
+                    return .value(false)
+                }
+
+                let exists = FileManager.default.fileExists(atPath: resolvedPath)
+                return .value(exists)
+            }
+            fsTable["exists"] = existsFn
+        }
+
+        // fig.fs.readFile(path) -> string or nil
+        if capabilities.contains(.fsReadProject) {
+            let readFileFn = sandbox.vm.vm.createFunction([String.arg]) { args in
+                let path = args.string
+
+                // Only allow reading within plugin directory for safety
+                let fullPath = sandbox.pluginPath.appendingPathComponent(path)
+                let resolvedPath = fullPath.standardizedFileURL.path
+                let pluginBasePath = sandbox.pluginPath.standardizedFileURL.path
+
+                guard resolvedPath.hasPrefix(pluginBasePath) else {
+                    Log.general.warning("Plugin attempted to read file outside sandbox: \(path)")
+                    return .nothing
+                }
+
+                guard let contents = try? String(contentsOfFile: resolvedPath, encoding: .utf8) else {
+                    return .nothing
+                }
+
+                return .value(contents)
+            }
+            fsTable["readFile"] = readFileFn
+        }
+
+        figTable["fs"] = fsTable
+    }
+}
+
+// MARK: - PluginAPIRegistry
+
+/// Protocol for receiving plugin API registrations.
+///
+/// Implementations of this protocol can receive health check and preset registrations
+/// from plugins via the Lua API.
+public protocol PluginAPIRegistry: AnyObject {
+    /// Called when a plugin registers a health check.
+    func registerHealthCheck(id: String, pluginId: String, function: Function)
+
+    /// Called when a plugin registers a preset.
+    func registerPreset(id: String, pluginId: String, options: Table)
+}

--- a/Fig/Sources/Services/Plugins/LuaPluginService.swift
+++ b/Fig/Sources/Services/Plugins/LuaPluginService.swift
@@ -394,45 +394,6 @@ public actor LuaPluginService {
         self.registrations.getPresets()
     }
 
-    // MARK: - Health Check Execution
-
-    /// Executes all registered plugin health checks.
-    ///
-    /// This method iterates through all health checks registered by plugins and
-    /// executes them with the provided context, returning the combined findings.
-    ///
-    /// - Parameter context: The health check context containing configuration data
-    /// - Returns: Array of findings from all plugin health checks
-    func executeHealthChecks(context: HealthCheckContext) -> [Finding] {
-        var findings: [Finding] = []
-        let healthChecks = self.registrations.getHealthChecks()
-
-        for (checkId, (pluginId, checkFunction)) in healthChecks {
-            // Get the sandbox for this plugin
-            guard let sandbox = pluginSandboxes[pluginId] else {
-                Log.general.warning("Plugin \(pluginId) has no active sandbox for health check \(checkId)")
-                continue
-            }
-
-            do {
-                let checkFindings = try PluginHealthCheckAdapter.executeCheck(
-                    checkId: checkId,
-                    pluginId: pluginId,
-                    function: checkFunction,
-                    sandbox: sandbox,
-                    context: context
-                )
-                findings.append(contentsOf: checkFindings)
-            } catch {
-                Log.general.warning(
-                    "Plugin health check \(checkId) from \(pluginId) failed: \(error.localizedDescription)"
-                )
-            }
-        }
-
-        return findings
-    }
-
     /// Grants capabilities to a plugin.
     ///
     /// - Parameters:
@@ -505,6 +466,47 @@ public actor LuaPluginService {
         } catch {
             Log.general.error("Plugin discovery failed: \(error.localizedDescription)")
         }
+    }
+
+    // MARK: Internal
+
+    // MARK: - Health Check Execution
+
+    /// Executes all registered plugin health checks.
+    ///
+    /// This method iterates through all health checks registered by plugins and
+    /// executes them with the provided context, returning the combined findings.
+    ///
+    /// - Parameter context: The health check context containing configuration data
+    /// - Returns: Array of findings from all plugin health checks
+    func executeHealthChecks(context: HealthCheckContext) -> [Finding] {
+        var findings: [Finding] = []
+        let healthChecks = self.registrations.getHealthChecks()
+
+        for (checkId, (pluginId, checkFunction)) in healthChecks {
+            // Get the sandbox for this plugin
+            guard let sandbox = pluginSandboxes[pluginId] else {
+                Log.general.warning("Plugin \(pluginId) has no active sandbox for health check \(checkId)")
+                continue
+            }
+
+            do {
+                let checkFindings = try PluginHealthCheckAdapter.executeCheck(
+                    checkId: checkId,
+                    pluginId: pluginId,
+                    function: checkFunction,
+                    sandbox: sandbox,
+                    context: context
+                )
+                findings.append(contentsOf: checkFindings)
+            } catch {
+                Log.general.warning(
+                    "Plugin health check \(checkId) from \(pluginId) failed: \(error.localizedDescription)"
+                )
+            }
+        }
+
+        return findings
     }
 
     // MARK: Private

--- a/Fig/Sources/Services/Plugins/LuaPluginService.swift
+++ b/Fig/Sources/Services/Plugins/LuaPluginService.swift
@@ -1,0 +1,597 @@
+import Foundation
+import lua4swift
+import OSLog
+
+// MARK: - PluginRegistrations
+
+/// Thread-safe storage for plugin registrations.
+///
+/// This class provides synchronized access to health checks and presets
+/// registered by plugins through the Lua API.
+final class PluginRegistrations: PluginAPIRegistry, @unchecked Sendable {
+    // MARK: Internal
+
+    /// Registered health checks: checkId -> (pluginId, function)
+    private(set) var healthChecks: [String: (String, Function)] = [:]
+
+    /// Registered presets: presetId -> (pluginId, options)
+    private(set) var presets: [String: (String, Table)] = [:]
+
+    func registerHealthCheck(id: String, pluginId: String, function: Function) {
+        self.lock.lock()
+        defer { lock.unlock() }
+        self.healthChecks[id] = (pluginId, function)
+    }
+
+    func registerPreset(id: String, pluginId: String, options: Table) {
+        self.lock.lock()
+        defer { lock.unlock() }
+        self.presets[id] = (pluginId, options)
+    }
+
+    func clearRegistrations(for pluginId: String) {
+        self.lock.lock()
+        defer { lock.unlock() }
+        self.healthChecks = self.healthChecks.filter { $0.value.0 != pluginId }
+        self.presets = self.presets.filter { $0.value.0 != pluginId }
+    }
+
+    func getHealthChecks() -> [String: (String, Function)] {
+        self.lock.lock()
+        defer { lock.unlock() }
+        return self.healthChecks
+    }
+
+    func getPresets() -> [String: (String, Table)] {
+        self.lock.lock()
+        defer { lock.unlock() }
+        return self.presets
+    }
+
+    // MARK: Private
+
+    private let lock = NSLock()
+}
+
+// MARK: - LuaPluginService
+
+/// Actor responsible for managing Lua plugin lifecycle and execution.
+///
+/// This service handles plugin discovery, loading, unloading, and hook execution.
+/// All Lua VM access is serialized through this actor to ensure thread safety.
+///
+/// Plugin locations searched (in order):
+/// 1. Built-in plugins (bundled with Fig)
+/// 2. User plugins (~/.fig/plugins/)
+/// 3. App support plugins (~/Library/Application Support/Fig/plugins/)
+public actor LuaPluginService {
+    // MARK: Lifecycle
+
+    private init() {
+        self.registrations = PluginRegistrations()
+        Log.general.debug("LuaPluginService initialized")
+    }
+
+    // MARK: Public
+
+    /// Shared instance for app-wide plugin management.
+    public static let shared = LuaPluginService()
+
+    // MARK: - Plugin Discovery
+
+    /// Discovers all plugins from standard locations.
+    ///
+    /// - Returns: Array of discovered plugins with their manifests
+    /// - Throws: If a manifest file is found but cannot be parsed
+    public func discoverPlugins() async throws -> [LoadedPlugin] {
+        var discovered: [LoadedPlugin] = []
+
+        for location in self.pluginSearchPaths {
+            guard self.fileManager.fileExists(atPath: location.path) else {
+                continue
+            }
+
+            let contents = try fileManager.contentsOfDirectory(
+                at: location,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+
+            for url in contents {
+                var isDirectory: ObjCBool = false
+                guard self.fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory),
+                      isDirectory.boolValue
+                else {
+                    continue
+                }
+
+                // Look for plugin manifest
+                let manifestURL = url.appendingPathComponent("plugin.json")
+                guard self.fileManager.fileExists(atPath: manifestURL.path) else {
+                    continue
+                }
+
+                do {
+                    let manifest = try loadManifest(from: manifestURL)
+
+                    // Check if already discovered (earlier paths take precedence)
+                    guard !discovered.contains(where: { $0.id == manifest.id }) else {
+                        Log.general.debug("Skipping duplicate plugin: \(manifest.id)")
+                        continue
+                    }
+
+                    // Check if disabled
+                    let state: PluginLifecycleState = self.installationState.isDisabled(manifest.id)
+                        ? .disabled
+                        : .discovered
+
+                    // Get granted capabilities
+                    let grantedCapabilities = self.installationState.capabilities(for: manifest.id)
+
+                    let plugin = LoadedPlugin(
+                        manifest: manifest,
+                        path: url,
+                        state: state,
+                        grantedCapabilities: grantedCapabilities
+                    )
+                    discovered.append(plugin)
+
+                    Log.general.info("Discovered plugin: \(manifest.id) v\(manifest.version) at \(url.path)")
+
+                } catch {
+                    Log.general.warning(
+                        "Failed to load plugin manifest at \(manifestURL.path): \(error.localizedDescription)"
+                    )
+                }
+            }
+        }
+
+        return discovered
+    }
+
+    /// Loads and initializes a plugin.
+    ///
+    /// - Parameter id: The plugin ID to load
+    /// - Throws: `PluginError` if loading fails
+    public func loadPlugin(id: String) async throws {
+        guard let plugin = loadedPlugins[id] else {
+            throw PluginError.pluginNotFound(id: id)
+        }
+
+        guard plugin.state == .discovered || plugin.state == .error else {
+            if plugin.state == .active {
+                throw PluginError.alreadyLoaded(id: id)
+            }
+            if plugin.state == .disabled {
+                throw PluginError.loadFailed(id: id, reason: "Plugin is disabled")
+            }
+            return
+        }
+
+        // Update state to loading
+        var updatedPlugin = plugin
+        updatedPlugin.state = .loading
+        self.loadedPlugins[id] = updatedPlugin
+
+        do {
+            // Create sandbox with granted capabilities
+            let sandbox = try LuaSandbox(
+                capabilities: plugin.grantedCapabilities,
+                pluginPath: plugin.path
+            )
+
+            // Register the Fig API before loading plugin code
+            LuaFigAPI.register(with: sandbox, pluginId: id, registry: self.registrations)
+
+            // Load the main Lua file
+            let mainFile = plugin.path.appendingPathComponent(plugin.manifest.main)
+            try sandbox.loadFile(mainFile)
+
+            // Call plugin's init function if present
+            if sandbox.hasFunction("plugin_init") {
+                _ = try sandbox.call("plugin_init")
+            }
+
+            // Store sandbox and update state
+            self.pluginSandboxes[id] = sandbox
+            updatedPlugin.state = .active
+            updatedPlugin.loadedAt = Date()
+            updatedPlugin.error = nil
+            self.loadedPlugins[id] = updatedPlugin
+
+            Log.general.info("Loaded plugin: \(id)")
+
+        } catch let error as PluginError {
+            updatedPlugin.state = .error
+            updatedPlugin.error = error
+            loadedPlugins[id] = updatedPlugin
+            throw error
+        } catch {
+            let pluginError = PluginError.loadFailed(id: id, reason: error.localizedDescription)
+            updatedPlugin.state = .error
+            updatedPlugin.error = pluginError
+            self.loadedPlugins[id] = updatedPlugin
+            throw pluginError
+        }
+    }
+
+    /// Unloads a plugin.
+    ///
+    /// - Parameter id: The plugin ID to unload
+    public func unloadPlugin(id: String) async {
+        guard var plugin = loadedPlugins[id] else {
+            return
+        }
+
+        plugin.state = .unloading
+        self.loadedPlugins[id] = plugin
+
+        // Call plugin's cleanup function if present
+        if let sandbox = pluginSandboxes[id] {
+            if sandbox.hasFunction("plugin_cleanup") {
+                do {
+                    _ = try sandbox.call("plugin_cleanup")
+                } catch {
+                    Log.general.warning("Plugin \(id) cleanup failed: \(error.localizedDescription)")
+                }
+            }
+        }
+
+        // Remove sandbox and clear registrations
+        self.pluginSandboxes.removeValue(forKey: id)
+        self.registrations.clearRegistrations(for: id)
+
+        // Update state
+        plugin.state = .discovered
+        plugin.loadedAt = nil
+        self.loadedPlugins[id] = plugin
+
+        Log.general.info("Unloaded plugin: \(id)")
+    }
+
+    /// Reloads a plugin (unload then load).
+    ///
+    /// - Parameter id: The plugin ID to reload
+    /// - Throws: `PluginError` if reloading fails
+    public func reloadPlugin(id: String) async throws {
+        await self.unloadPlugin(id: id)
+        try await self.loadPlugin(id: id)
+    }
+
+    /// Enables a previously disabled plugin.
+    ///
+    /// - Parameter id: The plugin ID to enable
+    public func enablePlugin(id: String) async {
+        self.installationState.disabledPlugins.remove(id)
+
+        if var plugin = loadedPlugins[id], plugin.state == .disabled {
+            plugin.state = .discovered
+            self.loadedPlugins[id] = plugin
+        }
+
+        await self.saveInstallationState()
+    }
+
+    /// Disables a plugin.
+    ///
+    /// - Parameter id: The plugin ID to disable
+    public func disablePlugin(id: String) async {
+        // Unload if active
+        await self.unloadPlugin(id: id)
+
+        self.installationState.disabledPlugins.insert(id)
+
+        if var plugin = loadedPlugins[id] {
+            plugin.state = .disabled
+            self.loadedPlugins[id] = plugin
+        }
+
+        await self.saveInstallationState()
+    }
+
+    // MARK: - Hook Execution
+
+    /// Executes all registered hooks for a given event.
+    ///
+    /// - Parameter context: The hook execution context
+    /// - Returns: Array of results from all matching hooks
+    public func executeHooks(context: HookExecutionContext) async -> [PluginHookResult] {
+        var results: [PluginHookResult] = []
+
+        for (id, plugin) in self.loadedPlugins where plugin.isActive {
+            // Check if plugin has registered for this hook
+            guard let hooks = plugin.manifest.hooks,
+                  hooks.contains(where: { $0.event == context.event })
+            else {
+                continue
+            }
+
+            guard let sandbox = pluginSandboxes[id] else {
+                continue
+            }
+
+            // Find the handler function name
+            let hookRegistration = hooks.first { $0.event == context.event }
+            let handlerName = hookRegistration?.handler ?? "on_\(context.event.lowercased())"
+
+            guard sandbox.hasFunction(handlerName) else {
+                Log.general.warning("Plugin \(id) registered for \(context.event) but missing handler \(handlerName)")
+                continue
+            }
+
+            let startTime = Date()
+
+            do {
+                // Convert context to Lua table
+                let contextTable = sandbox.createTable(from: context.toDictionary())
+
+                // Call the handler
+                let result = try sandbox.call(handlerName, args: [contextTable])
+
+                let duration = Date().timeIntervalSince(startTime)
+
+                // Parse result if it's a table
+                var output: [String: AnyCodable]?
+                if case let .values(values) = result,
+                   let table = values.first as? Table
+                {
+                    output = tableToDict(table)
+                }
+
+                results.append(PluginHookResult(
+                    pluginId: id,
+                    hookEvent: context.event,
+                    success: true,
+                    output: output,
+                    duration: duration
+                ))
+
+            } catch {
+                let duration = Date().timeIntervalSince(startTime)
+                results.append(PluginHookResult(
+                    pluginId: id,
+                    hookEvent: context.event,
+                    success: false,
+                    error: error.localizedDescription,
+                    duration: duration
+                ))
+
+                Log.general.warning(
+                    "Plugin \(id) hook \(context.event) failed: \(error.localizedDescription)"
+                )
+            }
+        }
+
+        return results
+    }
+
+    // MARK: - Plugin State
+
+    /// Returns all discovered plugins.
+    public func getPlugins() -> [LoadedPlugin] {
+        Array(self.loadedPlugins.values)
+    }
+
+    /// Returns a specific plugin by ID.
+    public func getPlugin(id: String) -> LoadedPlugin? {
+        self.loadedPlugins[id]
+    }
+
+    /// Returns all active plugins.
+    public func getActivePlugins() -> [LoadedPlugin] {
+        self.loadedPlugins.values.filter(\.isActive)
+    }
+
+    // MARK: - Plugin Registrations
+
+    /// Returns all registered health checks from plugins.
+    public func getRegisteredHealthChecks() -> [String: (String, Function)] {
+        self.registrations.getHealthChecks()
+    }
+
+    /// Returns all registered presets from plugins.
+    public func getRegisteredPresets() -> [String: (String, Table)] {
+        self.registrations.getPresets()
+    }
+
+    /// Grants capabilities to a plugin.
+    ///
+    /// - Parameters:
+    ///   - pluginId: The plugin ID
+    ///   - capabilities: Set of capabilities to grant
+    public func grantCapabilities(_ capabilities: Set<PluginCapability>, to pluginId: String) async {
+        let capabilityStrings = capabilities.map(\.rawValue)
+        var existing = self.installationState.grantedCapabilities[pluginId] ?? []
+        existing.formUnion(capabilityStrings)
+        self.installationState.grantedCapabilities[pluginId] = existing
+
+        // Update loaded plugin
+        if var plugin = loadedPlugins[pluginId] {
+            plugin.grantedCapabilities.formUnion(capabilities)
+            self.loadedPlugins[pluginId] = plugin
+        }
+
+        await self.saveInstallationState()
+    }
+
+    /// Revokes capabilities from a plugin.
+    ///
+    /// - Parameters:
+    ///   - pluginId: The plugin ID
+    ///   - capabilities: Set of capabilities to revoke
+    public func revokeCapabilities(_ capabilities: Set<PluginCapability>, from pluginId: String) async {
+        let capabilityStrings = capabilities.map(\.rawValue)
+        if var existing = installationState.grantedCapabilities[pluginId] {
+            existing.subtract(capabilityStrings)
+            self.installationState.grantedCapabilities[pluginId] = existing
+        }
+
+        // Update loaded plugin and potentially unload if capabilities changed
+        if var plugin = loadedPlugins[pluginId] {
+            plugin.grantedCapabilities.subtract(capabilities)
+            self.loadedPlugins[pluginId] = plugin
+
+            // If plugin is active and lost capabilities, reload it
+            if plugin.isActive {
+                try? await self.reloadPlugin(id: pluginId)
+            }
+        }
+
+        await self.saveInstallationState()
+    }
+
+    // MARK: - Initial Setup
+
+    /// Performs initial discovery and loads enabled plugins.
+    public func initialize() async {
+        await self.loadInstallationState()
+
+        do {
+            let discovered = try await discoverPlugins()
+            for plugin in discovered {
+                self.loadedPlugins[plugin.id] = plugin
+            }
+
+            // Auto-load enabled plugins
+            for plugin in discovered where plugin.state == .discovered {
+                do {
+                    try await loadPlugin(id: plugin.id)
+                } catch {
+                    Log.general.warning("Failed to auto-load plugin \(plugin.id): \(error.localizedDescription)")
+                }
+            }
+
+            Log.general.info("Plugin system initialized with \(self.loadedPlugins.count) plugins")
+
+        } catch {
+            Log.general.error("Plugin discovery failed: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: Private
+
+    /// Storage for plugin API registrations (health checks, presets).
+    private let registrations: PluginRegistrations
+
+    /// All currently tracked plugins, keyed by ID.
+    private var loadedPlugins: [String: LoadedPlugin] = [:]
+
+    /// Lua sandboxes for active plugins, keyed by plugin ID.
+    private var pluginSandboxes: [String: LuaSandbox] = [:]
+
+    /// Persistent installation state.
+    private var installationState = PluginInstallationState()
+
+    private let fileManager = FileManager.default
+
+    /// Standard plugin search paths.
+    private var pluginSearchPaths: [URL] {
+        var paths: [URL] = []
+
+        // 1. Built-in plugins (bundled with app)
+        if let bundlePath = Bundle.main.resourceURL?.appendingPathComponent("Plugins") {
+            paths.append(bundlePath)
+        }
+
+        // 2. User plugins (~/.fig/plugins/)
+        let userPlugins = self.fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent(".fig")
+            .appendingPathComponent("plugins")
+        paths.append(userPlugins)
+
+        // 3. App support plugins (~/Library/Application Support/Fig/plugins/)
+        if let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            let appSupportPlugins = appSupport
+                .appendingPathComponent("Fig")
+                .appendingPathComponent("plugins")
+            paths.append(appSupportPlugins)
+        }
+
+        return paths
+    }
+
+    /// Path to the installation state file.
+    private var installationStateURL: URL {
+        self.fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent(".fig")
+            .appendingPathComponent("plugin-state.json")
+    }
+
+    /// Loads the plugin manifest from a URL.
+    private func loadManifest(from url: URL) throws -> PluginManifest {
+        let data = try Data(contentsOf: url)
+        let decoder = JSONDecoder()
+        do {
+            return try decoder.decode(PluginManifest.self, from: data)
+        } catch {
+            throw PluginError.manifestInvalid(path: url.path, reason: error.localizedDescription)
+        }
+    }
+
+    /// Loads the persistent installation state.
+    private func loadInstallationState() async {
+        guard self.fileManager.fileExists(atPath: self.installationStateURL.path) else {
+            return
+        }
+
+        do {
+            let data = try Data(contentsOf: installationStateURL)
+            self.installationState = try JSONDecoder().decode(PluginInstallationState.self, from: data)
+        } catch {
+            Log.general.warning("Failed to load plugin state: \(error.localizedDescription)")
+        }
+    }
+
+    /// Saves the persistent installation state.
+    private func saveInstallationState() async {
+        do {
+            // Ensure directory exists
+            let directory = self.installationStateURL.deletingLastPathComponent()
+            try self.fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(self.installationState)
+            try data.write(to: self.installationStateURL, options: .atomic)
+        } catch {
+            Log.general.error("Failed to save plugin state: \(error.localizedDescription)")
+        }
+    }
+
+    /// Converts a Lua table to a Swift dictionary.
+    private func tableToDict(_ table: Table) -> [String: AnyCodable] {
+        var dict: [String: AnyCodable] = [:]
+
+        // Iterate through table keys
+        for key in table.keys() {
+            // Only handle string keys for dictionary conversion
+            if let stringKey = key as? String {
+                let value = table[key]
+                dict[stringKey] = self.valueToAnyCodable(value)
+            }
+        }
+
+        return dict
+    }
+
+    /// Converts a Lua value to AnyCodable.
+    private func valueToAnyCodable(_ value: Value) -> AnyCodable {
+        switch value.kind() {
+        case .string:
+            return AnyCodable(value as? String ?? "")
+        case .number:
+            return AnyCodable((value as? Number)?.toDouble() ?? 0)
+        case .boolean:
+            return AnyCodable(value as? Bool ?? false)
+        case .table:
+            if let table = value as? Table {
+                return AnyCodable(self.tableToDict(table))
+            }
+            return AnyCodable([:] as [String: Any])
+        case .nil:
+            return AnyCodable(NSNull())
+        default:
+            return AnyCodable(NSNull())
+        }
+    }
+}

--- a/Fig/Sources/Services/Plugins/LuaPluginService.swift
+++ b/Fig/Sources/Services/Plugins/LuaPluginService.swift
@@ -394,6 +394,45 @@ public actor LuaPluginService {
         self.registrations.getPresets()
     }
 
+    // MARK: - Health Check Execution
+
+    /// Executes all registered plugin health checks.
+    ///
+    /// This method iterates through all health checks registered by plugins and
+    /// executes them with the provided context, returning the combined findings.
+    ///
+    /// - Parameter context: The health check context containing configuration data
+    /// - Returns: Array of findings from all plugin health checks
+    func executeHealthChecks(context: HealthCheckContext) -> [Finding] {
+        var findings: [Finding] = []
+        let healthChecks = self.registrations.getHealthChecks()
+
+        for (checkId, (pluginId, checkFunction)) in healthChecks {
+            // Get the sandbox for this plugin
+            guard let sandbox = pluginSandboxes[pluginId] else {
+                Log.general.warning("Plugin \(pluginId) has no active sandbox for health check \(checkId)")
+                continue
+            }
+
+            do {
+                let checkFindings = try PluginHealthCheckAdapter.executeCheck(
+                    checkId: checkId,
+                    pluginId: pluginId,
+                    function: checkFunction,
+                    sandbox: sandbox,
+                    context: context
+                )
+                findings.append(contentsOf: checkFindings)
+            } catch {
+                Log.general.warning(
+                    "Plugin health check \(checkId) from \(pluginId) failed: \(error.localizedDescription)"
+                )
+            }
+        }
+
+        return findings
+    }
+
     /// Grants capabilities to a plugin.
     ///
     /// - Parameters:

--- a/Fig/Sources/Services/Plugins/LuaSandbox.swift
+++ b/Fig/Sources/Services/Plugins/LuaSandbox.swift
@@ -1,0 +1,333 @@
+import Foundation
+import lua4swift
+import OSLog
+import SwiftyLua
+
+// MARK: - LuaSandbox
+
+/// A sandboxed Lua virtual machine with restricted capabilities.
+///
+/// Security measures implemented:
+/// - Removes dangerous functions (`os.execute`, `io.*`, `debug.*`, `loadfile`, `dofile`)
+/// - Restricts file access to the plugin directory
+/// - Provides capability-based API exposure
+///
+/// The sandbox uses SwiftyLua/lua4swift under the hood but applies security restrictions
+/// before any plugin code can execute.
+///
+/// - Note: This class is `@unchecked Sendable` because Lua VMs
+///   are not inherently thread-safe. All access should be through the `LuaPluginService` actor.
+public final class LuaSandbox: @unchecked Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a new sandboxed Lua VM.
+    ///
+    /// - Parameters:
+    ///   - capabilities: Set of capabilities granted to the plugin
+    ///   - pluginPath: Path to the plugin directory (for sandboxed file access)
+    /// - Throws: `PluginError.loadFailed` if sandbox configuration fails
+    public init(
+        capabilities: Set<PluginCapability>,
+        pluginPath: URL
+    ) throws {
+        self.capabilities = capabilities
+        self.pluginPath = pluginPath
+
+        // Create VM with standard libraries, then restrict them
+        self.vm = LuaVM(openLibs: true)
+
+        try self.configureSandbox()
+
+        Log.general.debug("Created Lua sandbox for plugin at \(pluginPath.path)")
+    }
+
+    deinit {
+        Log.general.debug("Lua sandbox destroyed for \(self.pluginPath.path)")
+    }
+
+    // MARK: Public
+
+    /// Gets the last error message from the Lua VM.
+    public var lastError: String?
+
+    /// The capabilities granted to this sandbox.
+    public let capabilities: Set<PluginCapability>
+
+    /// Path to the plugin directory.
+    public let pluginPath: URL
+
+    /// The underlying LuaVM instance.
+    public let vm: LuaVM
+
+    /// Loads a Lua file into the sandbox.
+    ///
+    /// - Parameter url: Path to the Lua file
+    /// - Throws: `PluginError.securityViolation` if file is outside plugin directory,
+    ///           `PluginError.loadFailed` if the file cannot be loaded
+    public func loadFile(_ url: URL) throws {
+        // Verify file is within plugin directory
+        let resolvedPath = url.standardizedFileURL.path
+        let pluginBasePath = self.pluginPath.standardizedFileURL.path
+
+        guard resolvedPath.hasPrefix(pluginBasePath) else {
+            throw PluginError.securityViolation(
+                reason: "Cannot load files outside plugin directory: \(url.path)"
+            )
+        }
+
+        guard FileManager.default.fileExists(atPath: resolvedPath) else {
+            throw PluginError.loadFailed(
+                id: self.pluginPath.lastPathComponent,
+                reason: "File not found: \(url.lastPathComponent)"
+            )
+        }
+
+        do {
+            try self.vm.execute(url: url)
+        } catch {
+            throw PluginError.luaError(message: error.localizedDescription)
+        }
+    }
+
+    /// Executes Lua code string in the sandbox.
+    ///
+    /// - Parameter code: Lua code to execute
+    /// - Returns: Execution result
+    /// - Throws: `PluginError.luaError` if execution fails
+    @discardableResult
+    public func execute(_ code: String) throws -> VirtualMachine.EvalResults {
+        do {
+            return try self.vm.execute(string: code)
+        } catch {
+            throw PluginError.luaError(message: error.localizedDescription)
+        }
+    }
+
+    /// Calls a global Lua function by name.
+    ///
+    /// - Parameters:
+    ///   - name: Name of the function
+    ///   - args: Arguments to pass to the function
+    /// - Returns: Result of the function call
+    /// - Throws: `PluginError.functionNotFound` if function doesn't exist,
+    ///           `PluginError.executionFailed` if execution fails
+    public func call(_ name: String, args: [Value] = []) throws -> FunctionResults {
+        guard let function = vm.globals[name] as? Function else {
+            throw PluginError.functionNotFound(name: name)
+        }
+
+        let result = function.call(args)
+        if case let .error(message) = result {
+            throw PluginError.executionFailed(
+                id: self.pluginPath.lastPathComponent,
+                function: name,
+                reason: message
+            )
+        }
+
+        return result
+    }
+
+    /// Checks if a global function exists.
+    ///
+    /// - Parameter name: Name of the function
+    /// - Returns: True if the function exists
+    public func hasFunction(_ name: String) -> Bool {
+        self.vm.globals[name] is Function
+    }
+
+    /// Gets a global value.
+    public func getGlobal(_ name: String) -> Value? {
+        let value = self.vm.globals[name]
+        // Return nil for Lua nil values
+        if value is Nil {
+            return nil
+        }
+        return value
+    }
+
+    /// Sets a global value.
+    public func setGlobal(_ name: String, value: Value) {
+        self.vm.globals[name] = value
+    }
+
+    /// Sets a global value to nil.
+    public func setGlobalNil(_ name: String) {
+        // Use Lua code to set the value to nil
+        _ = try? self.execute("\(name) = nil")
+    }
+
+    /// Creates a Lua table.
+    public func createTable() -> Table {
+        self.vm.vm.createTable()
+    }
+
+    /// Creates a Lua table with a dictionary of string keys.
+    public func createTable(from dict: [String: Any]) -> Table {
+        let table = self.vm.vm.createTable()
+        for (key, value) in dict {
+            if let luaValue = anyToLuaValue(value) {
+                table[key] = luaValue
+            }
+        }
+        return table
+    }
+
+    /// Registers a Swift function as a global Lua function.
+    ///
+    /// - Parameters:
+    ///   - name: Global name for the function
+    ///   - parameters: Type checkers for parameters
+    ///   - function: Swift function to register
+    public func registerFunction(
+        _ name: String,
+        parameters: [TypeChecker] = [],
+        function: @escaping SwiftFunction
+    ) {
+        let descriptor = FunctionDescriptor(name: name, parameters: parameters, fn: function)
+        self.vm.registerFunction(descriptor)
+    }
+
+    /// Registers a table of functions as a Lua library.
+    ///
+    /// - Parameters:
+    ///   - name: Library name (global table name)
+    ///   - functions: Array of function descriptors
+    public func registerLibrary(
+        _ name: String,
+        functions: [FunctionDescriptor]
+    ) {
+        let library = self.vm.vm.createTable()
+        self.vm.registerFunctions(functions, library: library)
+        self.vm.globals[name] = library
+    }
+
+    // MARK: Private
+
+    /// Configures the sandbox by removing dangerous functions.
+    private func configureSandbox() throws {
+        // Remove dangerous global functions using Lua code
+        self.removeDangerousGlobals()
+
+        // Sandbox the os library
+        self.sandboxOsLibrary()
+
+        // Remove io library entirely
+        self.removeLibrary("io")
+
+        // Remove debug library entirely (but keep reference for function calls)
+        // Note: debug.traceback is used by lua4swift for error handling,
+        // so we need to be careful here
+        self.sandboxDebugLibrary()
+
+        // Sandbox package library
+        self.sandboxPackageLibrary()
+
+        // Add safe utility functions
+        self.addSafeUtilities()
+    }
+
+    /// Removes dangerous global functions.
+    private func removeDangerousGlobals() {
+        let dangerous = [
+            "dofile",
+            "loadfile",
+            "load",
+            "loadstring",
+        ]
+
+        for name in dangerous {
+            _ = try? self.execute("\(name) = nil")
+        }
+    }
+
+    /// Sandboxes the os library, keeping only safe functions.
+    private func sandboxOsLibrary() {
+        // Remove dangerous os functions using Lua code
+        let dangerous = [
+            "execute", "exit", "getenv", "remove", "rename",
+            "setlocale", "tmpname",
+        ]
+
+        for name in dangerous {
+            _ = try? self.execute("os.\(name) = nil")
+        }
+    }
+
+    /// Removes a library entirely.
+    private func removeLibrary(_ name: String) {
+        _ = try? self.execute("\(name) = nil")
+    }
+
+    /// Sandboxes the debug library.
+    private func sandboxDebugLibrary() {
+        // Keep only traceback for error handling, remove everything else
+        let toRemove = [
+            "debug", "getfenv", "gethook", "getinfo", "getlocal",
+            "getmetatable", "getregistry", "getupvalue", "getuservalue",
+            "setfenv", "sethook", "setlocal", "setmetatable",
+            "setupvalue", "setuservalue", "upvalueid", "upvaluejoin",
+        ]
+
+        for name in toRemove {
+            _ = try? self.execute("debug.\(name) = nil")
+        }
+    }
+
+    /// Sandboxes the package library.
+    private func sandboxPackageLibrary() {
+        // Remove dangerous package functions
+        _ = try? self.execute("package.loadlib = nil")
+        _ = try? self.execute("package.searchpath = nil")
+        _ = try? self.execute("package.searchers = nil")
+        _ = try? self.execute("package.loaders = nil")
+    }
+
+    /// Adds safe utility functions.
+    private func addSafeUtilities() {
+        // Register a Swift callback for logging
+        self.registerFunction("__fig_log", parameters: [String.arg]) { args in
+            let message = args.string
+            Log.general.info("Lua: \(message)")
+            return .nothing
+        }
+
+        // Create a safe print function in Lua that formats args and calls our callback
+        _ = try? self.execute("""
+        function print(...)
+            local args = {...}
+            local parts = {}
+            for i, v in ipairs(args) do
+                parts[i] = tostring(v)
+            end
+            __fig_log(table.concat(parts, "\\t"))
+        end
+        """)
+    }
+
+    /// Converts a Swift Any value to a Lua Value.
+    private func anyToLuaValue(_ value: Any) -> Value? {
+        switch value {
+        case let string as String:
+            return string
+        case let int as Int:
+            return Double(int)
+        case let double as Double:
+            return double
+        case let bool as Bool:
+            return bool
+        case let dict as [String: Any]:
+            return self.createTable(from: dict)
+        case let array as [Any]:
+            let table = self.vm.vm.createTable(array.count, keyCapacity: 0)
+            for (index, item) in array.enumerated() {
+                if let luaValue = anyToLuaValue(item) {
+                    table[index + 1] = luaValue // Lua arrays are 1-indexed
+                }
+            }
+            return table
+        default:
+            return nil
+        }
+    }
+}

--- a/Fig/Sources/Services/Plugins/PluginHealthCheckAdapter.swift
+++ b/Fig/Sources/Services/Plugins/PluginHealthCheckAdapter.swift
@@ -29,7 +29,7 @@ enum PluginHealthCheckAdapter {
         context: HealthCheckContext
     ) throws -> [Finding] {
         // Convert context to Lua table using the sandbox
-        let contextTable = createContextTable(sandbox: sandbox, context: context)
+        let contextTable = self.createContextTable(sandbox: sandbox, context: context)
 
         // Call the check function
         let result = function.call([contextTable])
@@ -39,7 +39,7 @@ enum PluginHealthCheckAdapter {
             guard let findingsTable = values.first as? Table else {
                 return []
             }
-            return parseFindingsTable(findingsTable, checkId: checkId)
+            return self.parseFindingsTable(findingsTable, checkId: checkId)
 
         case let .error(message):
             throw PluginError.executionFailed(
@@ -140,7 +140,7 @@ enum PluginHealthCheckAdapter {
         guard let severityString = table["severity"] as? String else {
             return nil
         }
-        let severity = parseSeverity(severityString)
+        let severity = self.parseSeverity(severityString)
 
         // Extract title
         guard let title = table["title"] as? String else {
@@ -153,7 +153,7 @@ enum PluginHealthCheckAdapter {
         }
 
         // Extract optional autoFix
-        let autoFix = parseAutoFix(table["autoFix"])
+        let autoFix = self.parseAutoFix(table["autoFix"])
 
         return Finding(
             severity: severity,
@@ -166,16 +166,18 @@ enum PluginHealthCheckAdapter {
     /// Converts a Lua severity string to a Swift Severity.
     private static func parseSeverity(_ string: String) -> Severity {
         switch string.lowercased() {
-        case "critical", "security":
-            return .security
+        case "critical",
+             "security":
+            .security
         case "warning":
-            return .warning
+            .warning
         case "suggestion":
-            return .suggestion
-        case "info", "good":
-            return .good
+            .suggestion
+        case "info",
+             "good":
+            .good
         default:
-            return .suggestion
+            .suggestion
         }
     }
 

--- a/Fig/Sources/Services/Plugins/PluginHealthCheckAdapter.swift
+++ b/Fig/Sources/Services/Plugins/PluginHealthCheckAdapter.swift
@@ -1,0 +1,204 @@
+import Foundation
+import lua4swift
+import OSLog
+
+// MARK: - PluginHealthCheckAdapter
+
+/// Bridges plugin-registered health checks with the existing Swift health check system.
+///
+/// This adapter converts `HealthCheckContext` to Lua tables, executes registered
+/// Lua health check functions, and converts the results back to Swift `Finding` types.
+enum PluginHealthCheckAdapter {
+    // MARK: Internal
+
+    /// Executes a single plugin health check using the provided sandbox.
+    ///
+    /// - Parameters:
+    ///   - checkId: Identifier for this health check
+    ///   - pluginId: The plugin that registered this check
+    ///   - function: The Lua function to execute
+    ///   - sandbox: The plugin's sandbox (used to create tables)
+    ///   - context: The health check context
+    /// - Returns: Array of findings from the check
+    /// - Throws: PluginError if execution fails
+    static func executeCheck(
+        checkId: String,
+        pluginId: String,
+        function: Function,
+        sandbox: LuaSandbox,
+        context: HealthCheckContext
+    ) throws -> [Finding] {
+        // Convert context to Lua table using the sandbox
+        let contextTable = createContextTable(sandbox: sandbox, context: context)
+
+        // Call the check function
+        let result = function.call([contextTable])
+
+        switch result {
+        case let .values(values):
+            guard let findingsTable = values.first as? Table else {
+                return []
+            }
+            return parseFindingsTable(findingsTable, checkId: checkId)
+
+        case let .error(message):
+            throw PluginError.executionFailed(
+                id: pluginId,
+                function: checkId,
+                reason: message
+            )
+        }
+    }
+
+    // MARK: Private
+
+    /// Creates a Lua table from the health check context.
+    private static func createContextTable(sandbox: LuaSandbox, context: HealthCheckContext) -> Table {
+        let table = sandbox.createTable()
+
+        // Add deny rules
+        let denyRulesTable = sandbox.createTable()
+        for (index, rule) in context.allDenyRules.enumerated() {
+            denyRulesTable[index + 1] = rule
+        }
+        table["denyRules"] = denyRulesTable
+
+        // Add allow rules
+        let allowRulesTable = sandbox.createTable()
+        for (index, rule) in context.allAllowRules.enumerated() {
+            allowRulesTable[index + 1] = rule
+        }
+        table["allowRules"] = allowRulesTable
+
+        // Add MCP servers
+        let mcpServersTable = sandbox.createTable()
+        for (name, server) in context.allMCPServers {
+            let serverTable = sandbox.createTable()
+
+            // Add env vars if present
+            if let env = server.env {
+                let envTable = sandbox.createTable()
+                for (key, value) in env {
+                    envTable[key] = value
+                }
+                serverTable["env"] = envTable
+            }
+
+            // Add headers if present
+            if let headers = server.headers {
+                let headersTable = sandbox.createTable()
+                for (key, value) in headers {
+                    headersTable[key] = value
+                }
+                serverTable["headers"] = headersTable
+            }
+
+            mcpServersTable[name] = serverTable
+        }
+        table["mcpServers"] = mcpServersTable
+
+        // Add boolean flags
+        table["localSettingsExists"] = context.localSettingsExists
+        table["mcpConfigExists"] = context.mcpConfigExists
+
+        // Add global config file size
+        if let size = context.globalConfigFileSize {
+            table["globalConfigFileSize"] = Double(size)
+        }
+
+        // Add convenience flags for plugins
+        let hasGlobalMCPServers = !(context.legacyConfig?.mcpServers?.isEmpty ?? true)
+        table["hasGlobalMCPServers"] = hasGlobalMCPServers
+
+        let hasHooks = (context.globalSettings?.hooks?.isEmpty == false)
+            || (context.projectSettings?.hooks?.isEmpty == false)
+            || (context.projectLocalSettings?.hooks?.isEmpty == false)
+        table["hasHooks"] = hasHooks
+
+        return table
+    }
+
+    /// Parses a Lua table of findings into Swift Finding objects.
+    private static func parseFindingsTable(_ table: Table, checkId: String) -> [Finding] {
+        var findings: [Finding] = []
+
+        // Lua arrays are 1-indexed
+        var index = 1
+        while let findingValue = table[index] as? Table {
+            if let finding = parseSingleFinding(findingValue) {
+                findings.append(finding)
+            }
+            index += 1
+        }
+
+        return findings
+    }
+
+    /// Parses a single Lua finding table into a Swift Finding.
+    private static func parseSingleFinding(_ table: Table) -> Finding? {
+        // Extract severity
+        guard let severityString = table["severity"] as? String else {
+            return nil
+        }
+        let severity = parseSeverity(severityString)
+
+        // Extract title
+        guard let title = table["title"] as? String else {
+            return nil
+        }
+
+        // Extract description
+        guard let description = table["description"] as? String else {
+            return nil
+        }
+
+        // Extract optional autoFix
+        let autoFix = parseAutoFix(table["autoFix"])
+
+        return Finding(
+            severity: severity,
+            title: title,
+            description: description,
+            autoFix: autoFix
+        )
+    }
+
+    /// Converts a Lua severity string to a Swift Severity.
+    private static func parseSeverity(_ string: String) -> Severity {
+        switch string.lowercased() {
+        case "critical", "security":
+            return .security
+        case "warning":
+            return .warning
+        case "suggestion":
+            return .suggestion
+        case "info", "good":
+            return .good
+        default:
+            return .suggestion
+        }
+    }
+
+    /// Parses an autoFix table from Lua.
+    private static func parseAutoFix(_ value: Value?) -> AutoFix? {
+        guard let table = value as? Table else {
+            return nil
+        }
+
+        guard let type = table["type"] as? String else {
+            return nil
+        }
+
+        switch type {
+        case "createLocalSettings":
+            return .createLocalSettings
+        case "addRule":
+            if let rule = table["rule"] as? String {
+                return .addToDenyList(pattern: rule)
+            }
+            return nil
+        default:
+            return nil
+        }
+    }
+}

--- a/Fig/Sources/ViewModels/ConfigHealthCheckViewModel.swift
+++ b/Fig/Sources/ViewModels/ConfigHealthCheckViewModel.swift
@@ -49,6 +49,9 @@ final class ConfigHealthCheckViewModel {
     }
 
     /// Runs all health checks against the current project configuration.
+    ///
+    /// This method runs both built-in Swift health checks and any health checks
+    /// registered by Lua plugins.
     func runChecks(
         globalSettings: ClaudeSettings?,
         projectSettings: ClaudeSettings?,
@@ -57,7 +60,7 @@ final class ConfigHealthCheckViewModel {
         legacyConfig: LegacyConfig?,
         localSettingsExists: Bool,
         mcpConfigExists: Bool
-    ) {
+    ) async {
         self.isRunning = true
 
         let context = HealthCheckContext(
@@ -72,7 +75,7 @@ final class ConfigHealthCheckViewModel {
             globalConfigFileSize: self.getGlobalConfigFileSize()
         )
 
-        self.findings = ConfigHealthCheckService.runAllChecks(context: context)
+        self.findings = await ConfigHealthCheckService.runAllChecksAsync(context: context)
         self.lastRunDate = Date()
         self.isRunning = false
     }

--- a/Fig/Sources/ViewModels/MCPCopyViewModel.swift
+++ b/Fig/Sources/ViewModels/MCPCopyViewModel.swift
@@ -71,17 +71,23 @@ final class MCPCopyViewModel {
 
     /// Whether the copy can proceed.
     var canCopy: Bool {
-        guard let destination = selectedDestination else { return false }
+        guard let destination = selectedDestination else {
+            return false
+        }
         // Can't copy to same location
-        if let source = sourceDestination, source == destination { return false }
+        if let source = sourceDestination, source == destination {
+            return false
+        }
         // Must acknowledge sensitive data if present
-        if !sensitiveWarnings.isEmpty && !acknowledgedSensitiveData { return false }
-        return !isCopying
+        if !self.sensitiveWarnings.isEmpty, !self.acknowledgedSensitiveData {
+            return false
+        }
+        return !self.isCopying
     }
 
     /// Loads available destinations from projects.
     func loadDestinations(projects: [ProjectEntry]) {
-        isLoadingDestinations = true
+        self.isLoadingDestinations = true
 
         var destinations: [CopyDestination] = [.global]
 
@@ -100,53 +106,53 @@ final class MCPCopyViewModel {
             destinations = destinations.filter { $0 != source }
         }
 
-        availableDestinations = destinations
-        isLoadingDestinations = false
+        self.availableDestinations = destinations
+        self.isLoadingDestinations = false
     }
 
     /// Checks for conflicts at the selected destination.
     func checkForConflict() async {
         guard let destination = selectedDestination else {
-            conflict = nil
+            self.conflict = nil
             return
         }
 
-        conflict = await MCPServerCopyService.shared.checkConflict(
-            serverName: serverName,
-            server: server,
+        self.conflict = await MCPServerCopyService.shared.checkConflict(
+            serverName: self.serverName,
+            server: self.server,
             destination: destination,
-            configManager: configManager
+            configManager: self.configManager
         )
 
         // Pre-fill renamed name if conflict exists
-        if conflict != nil {
-            renamedServerName = serverName + "-copy"
+        if self.conflict != nil {
+            self.renamedServerName = self.serverName + "-copy"
         }
     }
 
     /// Performs the copy with the specified resolution.
     func performCopy(resolution: CopyConflict.ConflictResolution? = nil) async {
-        guard let destination = selectedDestination else { return }
+        guard let destination = selectedDestination else {
+            return
+        }
 
-        isCopying = true
-        errorMessage = nil
-        copyResult = nil
+        self.isCopying = true
+        self.errorMessage = nil
+        self.copyResult = nil
 
         do {
-            let result: CopyResult
-
-            if let conflict, let resolution {
-                result = try await MCPServerCopyService.shared.copyServerWithResolution(
-                    name: serverName,
-                    server: server,
+            let result: CopyResult = if let conflict, let resolution {
+                try await MCPServerCopyService.shared.copyServerWithResolution(
+                    name: self.serverName,
+                    server: self.server,
                     to: destination,
                     resolution: resolution,
-                    configManager: configManager
+                    configManager: self.configManager
                 )
             } else if conflict != nil {
                 // Conflict exists but no resolution provided - skip
-                result = CopyResult(
-                    serverName: serverName,
+                CopyResult(
+                    serverName: self.serverName,
                     destination: destination,
                     success: false,
                     message: "Conflict not resolved",
@@ -155,16 +161,16 @@ final class MCPCopyViewModel {
                 )
             } else {
                 // No conflict, direct copy
-                result = try await MCPServerCopyService.shared.copyServer(
-                    name: serverName,
-                    server: server,
+                try await MCPServerCopyService.shared.copyServer(
+                    name: self.serverName,
+                    server: self.server,
                     to: destination,
                     strategy: .overwrite,
-                    configManager: configManager
+                    configManager: self.configManager
                 )
             }
 
-            copyResult = result
+            self.copyResult = result
 
             if result.success {
                 // Show success notification
@@ -174,34 +180,34 @@ final class MCPCopyViewModel {
                 )
             }
         } catch {
-            errorMessage = error.localizedDescription
+            self.errorMessage = error.localizedDescription
             NotificationManager.shared.showError(
                 "Copy failed",
                 message: error.localizedDescription
             )
         }
 
-        isCopying = false
+        self.isCopying = false
     }
 
     /// Copies with overwrite resolution.
     func copyWithOverwrite() async {
-        await performCopy(resolution: .overwrite)
+        await self.performCopy(resolution: .overwrite)
     }
 
     /// Copies with rename resolution.
     func copyWithRename() async {
-        let newName = renamedServerName.trimmingCharacters(in: .whitespaces)
+        let newName = self.renamedServerName.trimmingCharacters(in: .whitespaces)
         guard !newName.isEmpty else {
-            errorMessage = "Please enter a new name"
+            self.errorMessage = "Please enter a new name"
             return
         }
-        await performCopy(resolution: .rename(newName))
+        await self.performCopy(resolution: .rename(newName))
     }
 
     /// Skips the copy due to conflict.
     func skipCopy() async {
-        await performCopy(resolution: .skip)
+        await self.performCopy(resolution: .skip)
     }
 
     // MARK: Private

--- a/Fig/Sources/ViewModels/OnboardingViewModel.swift
+++ b/Fig/Sources/ViewModels/OnboardingViewModel.swift
@@ -32,6 +32,9 @@ final class OnboardingViewModel {
         case completion = 4
     }
 
+    /// Total number of tour pages.
+    static let tourPageCount = 4
+
     /// The current onboarding step.
     private(set) var currentStep: Step = .welcome
 
@@ -46,9 +49,6 @@ final class OnboardingViewModel {
 
     /// Current page index within the feature tour (0-based).
     var currentTourPage: Int = 0
-
-    /// Total number of tour pages.
-    static let tourPageCount = 4
 
     /// Whether the current step is the first step.
     var isFirstStep: Bool {

--- a/Fig/Sources/ViewModels/ProjectDetailViewModel.swift
+++ b/Fig/Sources/ViewModels/ProjectDetailViewModel.swift
@@ -363,20 +363,27 @@ final class ProjectDetailViewModel {
             switch source {
             case .projectShared:
                 // Delete from .mcp.json
-                guard var config = mcpConfig else { return }
+                guard var config = mcpConfig else {
+                    return
+                }
                 config.mcpServers?.removeValue(forKey: name)
-                try await configManager.writeMCPConfig(config, for: projectURL)
-                mcpConfig = config
+                try await self.configManager.writeMCPConfig(config, for: self.projectURL)
+                self.mcpConfig = config
                 NotificationManager.shared.showSuccess("Server deleted", message: "'\(name)' removed from project")
 
             case .global:
                 // Delete from ~/.claude.json
-                guard var globalConfig = try await configManager.readGlobalConfig() else { return }
+                guard var globalConfig = try await configManager.readGlobalConfig() else {
+                    return
+                }
                 globalConfig.mcpServers?.removeValue(forKey: name)
-                try await configManager.writeGlobalConfig(globalConfig)
+                try await self.configManager.writeGlobalConfig(globalConfig)
                 // Also update projectEntry if it exists
-                projectEntry = globalConfig.project(at: projectPath)
-                NotificationManager.shared.showSuccess("Server deleted", message: "'\(name)' removed from global config")
+                self.projectEntry = globalConfig.project(at: self.projectPath)
+                NotificationManager.shared.showSuccess(
+                    "Server deleted",
+                    message: "'\(name)' removed from global config"
+                )
 
             case .projectLocal:
                 // Local settings don't typically have MCP servers, but handle gracefully
@@ -405,7 +412,9 @@ final class ProjectDetailViewModel {
         ]
 
         for (settings, source) in sources {
-            guard let env = settings?.env else { continue }
+            guard let env = settings?.env else {
+                continue
+            }
             for (key, value) in env {
                 allValues[key, default: []].append((value, source))
             }

--- a/Fig/Sources/ViewModels/ProjectExplorerViewModel.swift
+++ b/Fig/Sources/ViewModels/ProjectExplorerViewModel.swift
@@ -258,7 +258,7 @@ final class ProjectExplorerViewModel {
                 return
             }
             config.projects?.removeValue(forKey: path)
-            try await configManager.writeGlobalConfig(config)
+            try await self.configManager.writeGlobalConfig(config)
 
             self.projects.removeAll { $0.path == path }
             self.favoritesStorage.removeProject(path)
@@ -296,7 +296,7 @@ final class ProjectExplorerViewModel {
                 config.projects?.removeValue(forKey: path)
             }
 
-            try await configManager.writeGlobalConfig(config)
+            try await self.configManager.writeGlobalConfig(config)
 
             let pathSet = Set(paths)
             self.projects.removeAll { pathSet.contains($0.path ?? "") }

--- a/Fig/Sources/Views/AttributionEditorViews.swift
+++ b/Fig/Sources/Views/AttributionEditorViews.swift
@@ -12,9 +12,9 @@ struct AttributionSettingsEditorView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
                 // Target selector
-                if !viewModel.isGlobalMode {
+                if !self.viewModel.isGlobalMode {
                     HStack {
-                        EditingTargetPicker(selection: $viewModel.editingTarget)
+                        EditingTargetPicker(selection: self.$viewModel.editingTarget)
                         Spacer()
                     }
                 }
@@ -22,7 +22,7 @@ struct AttributionSettingsEditorView: View {
                 // Attribution settings
                 GroupBox("Attribution") {
                     VStack(alignment: .leading, spacing: 12) {
-                        Toggle(isOn: commitBinding) {
+                        Toggle(isOn: self.commitBinding) {
                             VStack(alignment: .leading) {
                                 Text("Commit Attribution")
                                     .font(.body)
@@ -34,7 +34,7 @@ struct AttributionSettingsEditorView: View {
 
                         Divider()
 
-                        Toggle(isOn: pullRequestBinding) {
+                        Toggle(isOn: self.pullRequestBinding) {
                             VStack(alignment: .leading) {
                                 Text("Pull Request Attribution")
                                     .font(.body)
@@ -56,31 +56,31 @@ struct AttributionSettingsEditorView: View {
 
                         // Tag input area
                         FlowLayout(spacing: 8) {
-                            ForEach(viewModel.disallowedTools, id: \.self) { tool in
+                            ForEach(self.viewModel.disallowedTools, id: \.self) { tool in
                                 DisallowedToolTag(tool: tool) {
-                                    viewModel.removeDisallowedTool(tool)
+                                    self.viewModel.removeDisallowedTool(tool)
                                 }
                             }
 
                             // Add new tag
-                            if isAddingTool {
+                            if self.isAddingTool {
                                 AddToolInput(
-                                    toolName: $newToolName,
-                                    onAdd: addNewTool,
+                                    toolName: self.$newToolName,
+                                    onAdd: self.addNewTool,
                                     onCancel: {
-                                        isAddingTool = false
-                                        newToolName = ""
+                                        self.isAddingTool = false
+                                        self.newToolName = ""
                                     }
                                 )
                             } else {
                                 AddToolButton {
-                                    isAddingTool = true
+                                    self.isAddingTool = true
                                 }
                             }
                         }
                         .padding(.vertical, 4)
 
-                        if viewModel.disallowedTools.isEmpty, !isAddingTool {
+                        if self.viewModel.disallowedTools.isEmpty, !self.isAddingTool {
                             Text("No tools are disallowed")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
@@ -103,11 +103,11 @@ struct AttributionSettingsEditorView: View {
 
     private var commitBinding: Binding<Bool> {
         Binding(
-            get: { viewModel.attribution?.commits ?? false },
+            get: { self.viewModel.attribution?.commits ?? false },
             set: { newValue in
-                viewModel.updateAttribution(
+                self.viewModel.updateAttribution(
                     commits: newValue,
-                    pullRequests: viewModel.attribution?.pullRequests
+                    pullRequests: self.viewModel.attribution?.pullRequests
                 )
             }
         )
@@ -115,10 +115,10 @@ struct AttributionSettingsEditorView: View {
 
     private var pullRequestBinding: Binding<Bool> {
         Binding(
-            get: { viewModel.attribution?.pullRequests ?? false },
+            get: { self.viewModel.attribution?.pullRequests ?? false },
             set: { newValue in
-                viewModel.updateAttribution(
-                    commits: viewModel.attribution?.commits,
+                self.viewModel.updateAttribution(
+                    commits: self.viewModel.attribution?.commits,
                     pullRequests: newValue
                 )
             }
@@ -126,10 +126,12 @@ struct AttributionSettingsEditorView: View {
     }
 
     private func addNewTool() {
-        guard !newToolName.isEmpty else { return }
-        viewModel.addDisallowedTool(newToolName)
-        newToolName = ""
-        isAddingTool = false
+        guard !self.newToolName.isEmpty else {
+            return
+        }
+        self.viewModel.addDisallowedTool(self.newToolName)
+        self.newToolName = ""
+        self.isAddingTool = false
     }
 }
 
@@ -142,9 +144,9 @@ struct DisallowedToolTag: View {
 
     var body: some View {
         HStack(spacing: 4) {
-            Text(tool)
+            Text(self.tool)
                 .font(.system(.caption, design: .monospaced))
-            Button(action: onRemove) {
+            Button(action: self.onRemove) {
                 Image(systemName: "xmark")
                     .font(.caption2)
             }
@@ -161,27 +163,28 @@ struct DisallowedToolTag: View {
 /// Input field for adding a new disallowed tool.
 struct AddToolInput: View {
     @Binding var toolName: String
+
     let onAdd: () -> Void
     let onCancel: () -> Void
 
     var body: some View {
         HStack(spacing: 4) {
-            TextField("Tool name", text: $toolName)
+            TextField("Tool name", text: self.$toolName)
                 .textFieldStyle(.plain)
                 .font(.system(.caption, design: .monospaced))
                 .frame(minWidth: 80, maxWidth: 120)
                 .onSubmit {
-                    onAdd()
+                    self.onAdd()
                 }
 
-            Button(action: onAdd) {
+            Button(action: self.onAdd) {
                 Image(systemName: "checkmark")
                     .font(.caption2)
             }
             .buttonStyle(.plain)
-            .disabled(toolName.isEmpty)
+            .disabled(self.toolName.isEmpty)
 
-            Button(action: onCancel) {
+            Button(action: self.onCancel) {
                 Image(systemName: "xmark")
                     .font(.caption2)
             }
@@ -200,7 +203,7 @@ struct AddToolButton: View {
     let action: () -> Void
 
     var body: some View {
-        Button(action: action) {
+        Button(action: self.action) {
             HStack(spacing: 4) {
                 Image(systemName: "plus")
                     .font(.caption2)

--- a/Fig/Sources/Views/ClaudeMDView.swift
+++ b/Fig/Sources/Views/ClaudeMDView.swift
@@ -16,15 +16,15 @@ struct ClaudeMDView: View {
     var body: some View {
         HSplitView {
             // File hierarchy sidebar
-            claudeMDSidebar
+            self.claudeMDSidebar
                 .frame(minWidth: 180, idealWidth: 220, maxWidth: 280)
 
             // Content area
-            contentArea
+            self.contentArea
                 .frame(minWidth: 300)
         }
         .task {
-            await viewModel.loadFiles()
+            await self.viewModel.loadFiles()
         }
     }
 
@@ -44,7 +44,7 @@ struct ClaudeMDView: View {
                 Spacer()
                 Button {
                     Task {
-                        await viewModel.loadFiles()
+                        await self.viewModel.loadFiles()
                     }
                 } label: {
                     Image(systemName: "arrow.clockwise")
@@ -58,14 +58,14 @@ struct ClaudeMDView: View {
 
             Divider()
 
-            if viewModel.isLoading {
+            if self.viewModel.isLoading {
                 ProgressView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                List(selection: $viewModel.selectedFileID) {
+                List(selection: self.$viewModel.selectedFileID) {
                     // Global section
                     Section("Global") {
-                        ForEach(viewModel.files.filter { $0.level == .global }) { file in
+                        ForEach(self.viewModel.files.filter { $0.level == .global }) { file in
                             ClaudeMDFileRow(file: file)
                                 .tag(file.id)
                         }
@@ -74,7 +74,7 @@ struct ClaudeMDView: View {
                     // Project section
                     Section("Project") {
                         ForEach(
-                            viewModel.files.filter { $0.level != .global }
+                            self.viewModel.files.filter { $0.level != .global }
                         ) { file in
                             ClaudeMDFileRow(file: file)
                                 .tag(file.id)
@@ -82,8 +82,8 @@ struct ClaudeMDView: View {
                     }
                 }
                 .listStyle(.sidebar)
-                .onChange(of: viewModel.selectedFileID) { _, _ in
-                    viewModel.cancelEditing()
+                .onChange(of: self.viewModel.selectedFileID) { _, _ in
+                    self.viewModel.cancelEditing()
                 }
             }
         }
@@ -95,17 +95,17 @@ struct ClaudeMDView: View {
         VStack(spacing: 0) {
             if let file = viewModel.selectedFile {
                 // Toolbar
-                contentToolbar(for: file)
+                self.contentToolbar(for: file)
 
                 Divider()
 
                 // Content
-                if viewModel.isEditing {
-                    editorView
+                if self.viewModel.isEditing {
+                    self.editorView
                 } else if file.exists {
-                    previewView(for: file)
+                    self.previewView(for: file)
                 } else {
-                    emptyFileView(for: file)
+                    self.emptyFileView(for: file)
                 }
             } else {
                 ContentUnavailableView(
@@ -115,6 +115,15 @@ struct ClaudeMDView: View {
                 )
             }
         }
+    }
+
+    // MARK: - Editor
+
+    private var editorView: some View {
+        TextEditor(text: self.$viewModel.editContent)
+            .font(.system(.body, design: .monospaced))
+            .scrollContentBackground(.hidden)
+            .padding(4)
     }
 
     private func contentToolbar(for file: ClaudeMDFile) -> some View {
@@ -136,28 +145,28 @@ struct ClaudeMDView: View {
             }
 
             // Action buttons
-            if viewModel.isEditing {
+            if self.viewModel.isEditing {
                 Button("Cancel") {
-                    viewModel.cancelEditing()
+                    self.viewModel.cancelEditing()
                 }
 
                 Button("Save") {
                     Task {
-                        await viewModel.saveSelectedFile()
+                        await self.viewModel.saveSelectedFile()
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(viewModel.editContent == file.content)
+                .disabled(self.viewModel.editContent == file.content)
             } else if file.exists {
                 Button {
-                    viewModel.startEditing()
+                    self.viewModel.startEditing()
                 } label: {
                     Label("Edit", systemImage: "pencil")
                 }
             } else {
                 Button {
                     Task {
-                        await viewModel.createFile(at: file.level)
+                        await self.viewModel.createFile(at: file.level)
                     }
                 } label: {
                     Label("Create", systemImage: "plus")
@@ -181,15 +190,6 @@ struct ClaudeMDView: View {
         }
     }
 
-    // MARK: - Editor
-
-    private var editorView: some View {
-        TextEditor(text: $viewModel.editContent)
-            .font(.system(.body, design: .monospaced))
-            .scrollContentBackground(.hidden)
-            .padding(4)
-    }
-
     // MARK: - Empty State
 
     private func emptyFileView(for file: ClaudeMDFile) -> some View {
@@ -200,13 +200,12 @@ struct ClaudeMDView: View {
         } actions: {
             Button("Create File") {
                 Task {
-                    await viewModel.createFile(at: file.level)
+                    await self.viewModel.createFile(at: file.level)
                 }
             }
             .buttonStyle(.borderedProminent)
         }
     }
-
 }
 
 // MARK: - ClaudeMDFileRow
@@ -217,12 +216,12 @@ struct ClaudeMDFileRow: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            Image(systemName: file.exists ? "doc.text.fill" : "doc.badge.plus")
-                .foregroundStyle(file.exists ? .blue : .secondary)
+            Image(systemName: self.file.exists ? "doc.text.fill" : "doc.badge.plus")
+                .foregroundStyle(self.file.exists ? .blue : .secondary)
                 .frame(width: 16)
 
             VStack(alignment: .leading, spacing: 1) {
-                Text(file.level.displayName)
+                Text(self.file.level.displayName)
                     .font(.body)
                     .lineLimit(1)
 
@@ -236,8 +235,8 @@ struct ClaudeMDFileRow: View {
 
             Spacer()
 
-            if file.exists {
-                if file.isTrackedByGit {
+            if self.file.exists {
+                if self.file.isTrackedByGit {
                     Image(systemName: "checkmark.circle.fill")
                         .font(.caption2)
                         .foregroundStyle(.green)
@@ -262,10 +261,10 @@ struct GitStatusBadge: View {
 
     var body: some View {
         HStack(spacing: 4) {
-            Image(systemName: isTracked ? "checkmark.circle.fill" : "circle.dashed")
-                .foregroundStyle(isTracked ? .green : .orange)
+            Image(systemName: self.isTracked ? "checkmark.circle.fill" : "circle.dashed")
+                .foregroundStyle(self.isTracked ? .green : .orange)
                 .font(.caption)
-            Text(isTracked ? "In git" : "Untracked")
+            Text(self.isTracked ? "In git" : "Untracked")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/Fig/Sources/Views/ConfigExportView.swift
+++ b/Fig/Sources/Views/ConfigExportView.swift
@@ -8,12 +8,10 @@ struct ConfigExportView: View {
 
     @Bindable var viewModel: ConfigExportViewModel
 
-    @Environment(\.dismiss) private var dismiss
-
     var body: some View {
         VStack(spacing: 0) {
             // Header
-            header
+            self.header
 
             Divider()
 
@@ -21,21 +19,21 @@ struct ConfigExportView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
                     // Component selection
-                    componentSelectionSection
+                    self.componentSelectionSection
 
                     // Sensitive data warning
-                    if viewModel.includeLocalSettings {
-                        sensitiveDataWarning
+                    if self.viewModel.includeLocalSettings {
+                        self.sensitiveDataWarning
                     }
 
                     // Error message
                     if let error = viewModel.errorMessage {
-                        errorSection(error: error)
+                        self.errorSection(error: error)
                     }
 
                     // Success message
-                    if viewModel.exportSuccessful {
-                        successSection
+                    if self.viewModel.exportSuccessful {
+                        self.successSection
                     }
                 }
                 .padding()
@@ -44,15 +42,17 @@ struct ConfigExportView: View {
             Divider()
 
             // Footer
-            footer
+            self.footer
         }
         .frame(width: 450, height: 400)
         .task {
-            await viewModel.loadAvailableComponents()
+            await self.viewModel.loadAvailableComponents()
         }
     }
 
     // MARK: Private
+
+    @Environment(\.dismiss) private var dismiss
 
     private var header: some View {
         HStack {
@@ -63,7 +63,7 @@ struct ConfigExportView: View {
             VStack(alignment: .leading) {
                 Text("Export Configuration")
                     .font(.headline)
-                Text(viewModel.projectName)
+                Text(self.viewModel.projectName)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
@@ -80,22 +80,22 @@ struct ConfigExportView: View {
                     .font(.subheadline)
                     .fontWeight(.medium)
 
-                if viewModel.availableComponents.isEmpty {
+                if self.viewModel.availableComponents.isEmpty {
                     Text("No configuration found in this project.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 } else {
                     ForEach(ConfigBundleComponent.allCases) { component in
-                        if viewModel.availableComponents.contains(component) {
+                        if self.viewModel.availableComponents.contains(component) {
                             ComponentToggle(
                                 component: component,
                                 isSelected: Binding(
-                                    get: { viewModel.selectedComponents.contains(component) },
+                                    get: { self.viewModel.selectedComponents.contains(component) },
                                     set: { selected in
                                         if selected {
-                                            viewModel.selectedComponents.insert(component)
+                                            self.viewModel.selectedComponents.insert(component)
                                         } else {
-                                            viewModel.selectedComponents.remove(component)
+                                            self.viewModel.selectedComponents.remove(component)
                                         }
                                     }
                                 )
@@ -123,13 +123,13 @@ struct ConfigExportView: View {
 
                 Text(
                     "The local settings file (settings.local.json) may contain API keys, " +
-                    "tokens, or other sensitive information. Only share this export " +
-                    "file with trusted parties."
+                        "tokens, or other sensitive information. Only share this export " +
+                        "file with trusted parties."
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-                Toggle(isOn: $viewModel.acknowledgedSensitiveData) {
+                Toggle(isOn: self.$viewModel.acknowledgedSensitiveData) {
                     Text("I understand the risks")
                         .font(.subheadline)
                 }
@@ -137,21 +137,6 @@ struct ConfigExportView: View {
             .padding(.vertical, 4)
         } label: {
             Label("Security Warning", systemImage: "lock.shield")
-        }
-    }
-
-    @ViewBuilder
-    private func errorSection(error: String) -> some View {
-        GroupBox {
-            HStack {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundStyle(.red)
-                Text(error)
-                    .foregroundStyle(.red)
-            }
-            .padding(.vertical, 4)
-        } label: {
-            Label("Error", systemImage: "xmark.octagon")
         }
     }
 
@@ -181,30 +166,44 @@ struct ConfigExportView: View {
     private var footer: some View {
         HStack {
             Button("Cancel") {
-                dismiss()
+                self.dismiss()
             }
             .keyboardShortcut(.cancelAction)
 
             Spacer()
 
-            if viewModel.exportSuccessful {
+            if self.viewModel.exportSuccessful {
                 Button("Done") {
-                    dismiss()
+                    self.dismiss()
                 }
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
             } else {
                 Button("Export...") {
                     Task {
-                        await viewModel.performExport()
+                        await self.viewModel.performExport()
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(!viewModel.canExport)
+                .disabled(!self.viewModel.canExport)
                 .keyboardShortcut(.defaultAction)
             }
         }
         .padding()
+    }
+
+    private func errorSection(error: String) -> some View {
+        GroupBox {
+            HStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+                Text(error)
+                    .foregroundStyle(.red)
+            }
+            .padding(.vertical, 4)
+        } label: {
+            Label("Error", systemImage: "xmark.octagon")
+        }
     }
 }
 
@@ -213,15 +212,16 @@ struct ConfigExportView: View {
 /// Toggle for selecting a component with info.
 private struct ComponentToggle: View {
     let component: ConfigBundleComponent
+
     @Binding var isSelected: Bool
 
     var body: some View {
-        Toggle(isOn: $isSelected) {
+        Toggle(isOn: self.$isSelected) {
             HStack {
-                Image(systemName: component.icon)
+                Image(systemName: self.component.icon)
                     .frame(width: 20)
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(component.displayName)
+                    Text(self.component.displayName)
                         .font(.subheadline)
                     if let warning = component.sensitiveWarning {
                         Text(warning)

--- a/Fig/Sources/Views/ConfigHealthCheckView.swift
+++ b/Fig/Sources/Views/ConfigHealthCheckView.swift
@@ -23,7 +23,7 @@ struct ConfigHealthCheckView: View {
                 // Summary header
                 HealthCheckHeaderView(
                     healthVM: self.healthCheckVM,
-                    onRunChecks: { self.runChecks() }
+                    onRunChecks: { Task { await self.runChecks() } }
                 )
 
                 if self.healthCheckVM.isRunning {
@@ -54,7 +54,7 @@ struct ConfigHealthCheckView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .task {
-            self.runChecks()
+            await self.runChecks()
         }
     }
 
@@ -62,8 +62,8 @@ struct ConfigHealthCheckView: View {
 
     @State private var healthCheckVM: ConfigHealthCheckViewModel
 
-    private func runChecks() {
-        self.healthCheckVM.runChecks(
+    private func runChecks() async {
+        await self.healthCheckVM.runChecks(
             globalSettings: self.viewModel.globalSettings,
             projectSettings: self.viewModel.projectSettings,
             projectLocalSettings: self.viewModel.projectLocalSettings,

--- a/Fig/Sources/Views/ConfigImportView.swift
+++ b/Fig/Sources/Views/ConfigImportView.swift
@@ -8,19 +8,17 @@ struct ConfigImportView: View {
 
     @Bindable var viewModel: ConfigImportViewModel
 
-    @Environment(\.dismiss) private var dismiss
-
     var body: some View {
         VStack(spacing: 0) {
             // Header with step indicator
-            header
+            self.header
 
             Divider()
 
             // Step content
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
-                    stepContent
+                    self.stepContent
                 }
                 .padding()
             }
@@ -28,12 +26,14 @@ struct ConfigImportView: View {
             Divider()
 
             // Footer
-            footer
+            self.footer
         }
         .frame(width: 500, height: 500)
     }
 
     // MARK: Private
+
+    @Environment(\.dismiss) private var dismiss
 
     private var header: some View {
         VStack(spacing: 12) {
@@ -45,7 +45,7 @@ struct ConfigImportView: View {
                 VStack(alignment: .leading) {
                     Text("Import Configuration")
                         .font(.headline)
-                    Text(viewModel.projectName)
+                    Text(self.viewModel.projectName)
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }
@@ -58,13 +58,13 @@ struct ConfigImportView: View {
                 ForEach(Array(ImportWizardStep.allCases.enumerated()), id: \.element) { index, step in
                     if index > 0 {
                         Rectangle()
-                            .fill(step.rawValue <= viewModel.currentStep.rawValue
+                            .fill(step.rawValue <= self.viewModel.currentStep.rawValue
                                 ? Color.accentColor : Color.secondary.opacity(0.3))
                             .frame(height: 2)
                     }
 
                     Circle()
-                        .fill(step.rawValue <= viewModel.currentStep.rawValue
+                        .fill(step.rawValue <= self.viewModel.currentStep.rawValue
                             ? Color.accentColor : Color.secondary.opacity(0.3))
                         .frame(width: 10, height: 10)
                 }
@@ -76,17 +76,17 @@ struct ConfigImportView: View {
 
     @ViewBuilder
     private var stepContent: some View {
-        switch viewModel.currentStep {
+        switch self.viewModel.currentStep {
         case .selectFile:
-            selectFileStep
+            self.selectFileStep
         case .selectComponents:
-            selectComponentsStep
+            self.selectComponentsStep
         case .resolveConflicts:
-            resolveConflictsStep
+            self.resolveConflictsStep
         case .preview:
-            previewStep
+            self.previewStep
         case .complete:
-            completeStep
+            self.completeStep
         }
     }
 
@@ -143,13 +143,13 @@ struct ConfigImportView: View {
 
                 Button("Choose Different File...") {
                     Task {
-                        await viewModel.selectFile()
+                        await self.viewModel.selectFile()
                     }
                 }
             } else {
                 Button {
                     Task {
-                        await viewModel.selectFile()
+                        await self.viewModel.selectFile()
                     }
                 } label: {
                     VStack(spacing: 8) {
@@ -163,7 +163,7 @@ struct ConfigImportView: View {
                 .buttonStyle(.bordered)
             }
 
-            if viewModel.isLoading {
+            if self.viewModel.isLoading {
                 ProgressView("Loading bundle...")
             }
 
@@ -186,14 +186,14 @@ struct ConfigImportView: View {
 
             GroupBox {
                 VStack(alignment: .leading, spacing: 12) {
-                    ForEach(viewModel.availableComponents) { component in
+                    ForEach(self.viewModel.availableComponents) { component in
                         Toggle(isOn: Binding(
-                            get: { viewModel.selectedComponents.contains(component) },
+                            get: { self.viewModel.selectedComponents.contains(component) },
                             set: { selected in
                                 if selected {
-                                    viewModel.selectedComponents.insert(component)
+                                    self.viewModel.selectedComponents.insert(component)
                                 } else {
-                                    viewModel.selectedComponents.remove(component)
+                                    self.viewModel.selectedComponents.remove(component)
                                 }
                             }
                         )) {
@@ -218,7 +218,7 @@ struct ConfigImportView: View {
             }
 
             // Sensitive data warning
-            if viewModel.selectedComponents.contains(.localSettings) {
+            if self.viewModel.selectedComponents.contains(.localSettings) {
                 GroupBox {
                     VStack(alignment: .leading, spacing: 8) {
                         HStack {
@@ -229,7 +229,7 @@ struct ConfigImportView: View {
                         }
                         .font(.subheadline)
 
-                        Toggle(isOn: $viewModel.acknowledgedSensitiveData) {
+                        Toggle(isOn: self.$viewModel.acknowledgedSensitiveData) {
                             Text("I trust this bundle and want to import it")
                                 .font(.subheadline)
                         }
@@ -247,7 +247,7 @@ struct ConfigImportView: View {
             Text("The following conflicts were detected. Choose how to resolve them.")
                 .font(.subheadline)
 
-            ForEach(viewModel.conflicts) { conflict in
+            ForEach(self.viewModel.conflicts) { conflict in
                 GroupBox {
                     VStack(alignment: .leading, spacing: 8) {
                         HStack {
@@ -257,8 +257,8 @@ struct ConfigImportView: View {
                         }
 
                         Picker("Resolution", selection: Binding(
-                            get: { viewModel.resolutions[conflict.component] ?? .merge },
-                            set: { viewModel.resolutions[conflict.component] = $0 }
+                            get: { self.viewModel.resolutions[conflict.component] ?? .merge },
+                            set: { self.viewModel.resolutions[conflict.component] = $0 }
                         )) {
                             ForEach(ImportConflict.ImportResolution.allCases) { resolution in
                                 Text(resolution.displayName).tag(resolution)
@@ -281,7 +281,7 @@ struct ConfigImportView: View {
 
             GroupBox {
                 VStack(alignment: .leading, spacing: 8) {
-                    ForEach(Array(viewModel.selectedComponents)) { component in
+                    ForEach(Array(self.viewModel.selectedComponents)) { component in
                         HStack {
                             Image(systemName: "checkmark.circle.fill")
                                 .foregroundStyle(.green)
@@ -299,7 +299,7 @@ struct ConfigImportView: View {
                 Label("Components to Import", systemImage: "list.bullet")
             }
 
-            if viewModel.hasSensitiveData {
+            if self.viewModel.hasSensitiveData {
                 HStack {
                     Image(systemName: "lock.shield")
                         .foregroundStyle(.orange)
@@ -408,33 +408,33 @@ struct ConfigImportView: View {
 
     private var footer: some View {
         HStack {
-            if viewModel.canGoBack {
+            if self.viewModel.canGoBack {
                 Button("Back") {
-                    viewModel.previousStep()
+                    self.viewModel.previousStep()
                 }
             }
 
             Spacer()
 
-            if viewModel.currentStep == .complete {
+            if self.viewModel.currentStep == .complete {
                 Button("Done") {
-                    dismiss()
+                    self.dismiss()
                 }
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
             } else {
                 Button("Cancel") {
-                    dismiss()
+                    self.dismiss()
                 }
                 .keyboardShortcut(.cancelAction)
 
-                Button(viewModel.currentStep == .preview ? "Import" : "Next") {
+                Button(self.viewModel.currentStep == .preview ? "Import" : "Next") {
                     Task {
-                        await viewModel.nextStep()
+                        await self.viewModel.nextStep()
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(!viewModel.canProceed || viewModel.isImporting)
+                .disabled(!self.viewModel.canProceed || self.viewModel.isImporting)
                 .keyboardShortcut(.defaultAction)
             }
         }

--- a/Fig/Sources/Views/ConfigTabViews.swift
+++ b/Fig/Sources/Views/ConfigTabViews.swift
@@ -11,22 +11,22 @@ struct SourceBadge: View {
 
     var body: some View {
         HStack(spacing: 2) {
-            Image(systemName: source.icon)
+            Image(systemName: self.source.icon)
                 .font(.caption2)
-            Text(source.label)
+            Text(self.source.label)
                 .font(.caption2)
         }
         .padding(.horizontal, 6)
         .padding(.vertical, 2)
-        .background(backgroundColor.opacity(0.2), in: RoundedRectangle(cornerRadius: 4))
-        .foregroundStyle(backgroundColor)
-        .accessibilityLabel("Source: \(source.label)")
+        .background(self.backgroundColor.opacity(0.2), in: RoundedRectangle(cornerRadius: 4))
+        .foregroundStyle(self.backgroundColor)
+        .accessibilityLabel("Source: \(self.source.label)")
     }
 
     // MARK: Private
 
     private var backgroundColor: Color {
-        switch source {
+        switch self.source {
         case .global:
             .blue
         case .projectShared:
@@ -58,7 +58,7 @@ struct PermissionsTabView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
                 // Source legend for project views
-                if allPermissions != nil {
+                if self.allPermissions != nil {
                     SourceLegend()
                 }
 
@@ -69,7 +69,7 @@ struct PermissionsTabView: View {
                             .font(.headline)
                             .foregroundStyle(.green)
 
-                        let allowRules = allowPermissions
+                        let allowRules = self.allowPermissions
                         if allowRules.isEmpty {
                             Text("No allow rules configured.")
                                 .foregroundStyle(.secondary)
@@ -80,13 +80,13 @@ struct PermissionsTabView: View {
                                     rule: item.rule,
                                     type: .allow,
                                     source: item.source,
-                                    isOverride: isRuleOverridingGlobal(
+                                    isOverride: self.isRuleOverridingGlobal(
                                         rule: item.rule,
                                         type: .allow,
                                         source: item.source
                                     ),
-                                    onPromoteToGlobal: onPromoteToGlobal,
-                                    onCopyToScope: onCopyToScope
+                                    onPromoteToGlobal: self.onPromoteToGlobal,
+                                    onCopyToScope: self.onCopyToScope
                                 )
                             }
                         }
@@ -101,7 +101,7 @@ struct PermissionsTabView: View {
                             .font(.headline)
                             .foregroundStyle(.red)
 
-                        let denyRules = denyPermissions
+                        let denyRules = self.denyPermissions
                         if denyRules.isEmpty {
                             Text("No deny rules configured.")
                                 .foregroundStyle(.secondary)
@@ -112,13 +112,13 @@ struct PermissionsTabView: View {
                                     rule: item.rule,
                                     type: .deny,
                                     source: item.source,
-                                    isOverride: isRuleOverridingGlobal(
+                                    isOverride: self.isRuleOverridingGlobal(
                                         rule: item.rule,
                                         type: .deny,
                                         source: item.source
                                     ),
-                                    onPromoteToGlobal: onPromoteToGlobal,
-                                    onCopyToScope: onCopyToScope
+                                    onPromoteToGlobal: self.onPromoteToGlobal,
+                                    onCopyToScope: self.onCopyToScope
                                 )
                             }
                         }
@@ -156,7 +156,9 @@ struct PermissionsTabView: View {
 
     /// Checks if a project-level rule also exists at the global level.
     private func isRuleOverridingGlobal(rule: String, type: PermissionType, source: ConfigSource) -> Bool {
-        guard source != .global, let allPermissions else { return false }
+        guard source != .global, let allPermissions else {
+            return false
+        }
         return allPermissions.contains { $0.rule == rule && $0.type == type && $0.source == .global }
     }
 }
@@ -174,16 +176,16 @@ struct PermissionRuleRow: View {
 
     var body: some View {
         HStack {
-            Image(systemName: type.icon)
-                .foregroundStyle(type == .allow ? .green : .red)
+            Image(systemName: self.type.icon)
+                .foregroundStyle(self.type == .allow ? .green : .red)
                 .frame(width: 20)
 
-            Text(rule)
+            Text(self.rule)
                 .font(.system(.body, design: .monospaced))
                 .lineLimit(1)
                 .truncationMode(.middle)
 
-            if isOverride {
+            if self.isOverride {
                 Image(systemName: "arrow.up.arrow.down")
                     .foregroundStyle(.orange)
                     .font(.caption2)
@@ -192,34 +194,36 @@ struct PermissionRuleRow: View {
 
             Spacer()
 
-            SourceBadge(source: source)
+            SourceBadge(source: self.source)
         }
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(type == .allow ? "Allow" : "Deny") rule: \(rule), source: \(source.label)")
+        .accessibilityLabel(
+            "\(self.type == .allow ? "Allow" : "Deny") rule: \(self.rule), source: \(self.source.label)"
+        )
         .contextMenu {
             Button {
                 NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(rule, forType: .string)
+                NSPasteboard.general.setString(self.rule, forType: .string)
             } label: {
                 Label("Copy Rule", systemImage: "doc.on.doc")
             }
 
-            if source != .global, onPromoteToGlobal != nil {
+            if self.source != .global, self.onPromoteToGlobal != nil {
                 Divider()
 
                 Button {
-                    onPromoteToGlobal?(rule, type)
+                    self.onPromoteToGlobal?(self.rule, self.type)
                 } label: {
                     Label("Promote to Global", systemImage: "arrow.up.to.line")
                 }
             }
 
-            if source == .projectShared || source == .projectLocal {
-                let otherScope: ConfigSource = source == .projectShared ? .projectLocal : .projectShared
-                if onCopyToScope != nil {
+            if self.source == .projectShared || self.source == .projectLocal {
+                let otherScope: ConfigSource = self.source == .projectShared ? .projectLocal : .projectShared
+                if self.onCopyToScope != nil {
                     Button {
-                        onCopyToScope?(rule, type, otherScope)
+                        self.onCopyToScope?(self.rule, self.type, otherScope)
                     } label: {
                         Label("Copy to \(otherScope.label)", systemImage: "arrow.left.arrow.right")
                     }
@@ -239,20 +243,20 @@ struct EnvironmentTabView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                if !envVars.isEmpty {
+                if !self.envVars.isEmpty {
                     SourceLegend()
                 }
 
-                if envVars.isEmpty {
+                if self.envVars.isEmpty {
                     ContentUnavailableView(
                         "No Environment Variables",
                         systemImage: "list.bullet.rectangle",
-                        description: Text(emptyMessage)
+                        description: Text(self.emptyMessage)
                     )
                 } else {
                     GroupBox {
                         VStack(alignment: .leading, spacing: 0) {
-                            ForEach(Array(envVars.enumerated()), id: \.offset) { index, item in
+                            ForEach(Array(self.envVars.enumerated()), id: \.offset) { index, item in
                                 if index > 0 {
                                     Divider()
                                 }
@@ -285,7 +289,7 @@ struct EnvironmentVariableRow: View {
 
     var body: some View {
         HStack(alignment: .top) {
-            Text(key)
+            Text(self.key)
                 .font(.system(.body, design: .monospaced))
                 .fontWeight(.medium)
                 .frame(minWidth: 200, alignment: .leading)
@@ -294,31 +298,31 @@ struct EnvironmentVariableRow: View {
                 .foregroundStyle(.secondary)
 
             Group {
-                if isValueVisible || !isSensitive {
-                    Text(value)
+                if self.isValueVisible || !self.isSensitive {
+                    Text(self.value)
                         .font(.system(.body, design: .monospaced))
                         .lineLimit(2)
                         .truncationMode(.middle)
                 } else {
-                    Text(String(repeating: "\u{2022}", count: min(value.count, 20)))
+                    Text(String(repeating: "\u{2022}", count: min(self.value.count, 20)))
                         .font(.system(.body, design: .monospaced))
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            if isSensitive {
+            if self.isSensitive {
                 Button {
-                    isValueVisible.toggle()
+                    self.isValueVisible.toggle()
                 } label: {
-                    Image(systemName: isValueVisible ? "eye.slash" : "eye")
+                    Image(systemName: self.isValueVisible ? "eye.slash" : "eye")
                         .font(.caption)
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel(isValueVisible ? "Hide value" : "Show value")
-                .accessibilityHint("Toggles visibility of sensitive value for \(key)")
+                .accessibilityLabel(self.isValueVisible ? "Hide value" : "Show value")
+                .accessibilityHint("Toggles visibility of sensitive value for \(self.key)")
             }
 
-            SourceBadge(source: source)
+            SourceBadge(source: self.source)
         }
         .padding(.vertical, 8)
     }
@@ -329,7 +333,7 @@ struct EnvironmentVariableRow: View {
 
     private var isSensitive: Bool {
         let sensitivePatterns = ["token", "key", "secret", "password", "credential", "api"]
-        let lowercaseKey = key.lowercased()
+        let lowercaseKey = self.key.lowercased()
         return sensitivePatterns.contains { lowercaseKey.contains($0) }
     }
 }
@@ -349,11 +353,11 @@ struct MCPServersTabView: View {
     var body: some View {
         VStack(spacing: 0) {
             // Toolbar
-            if onAdd != nil {
+            if self.onAdd != nil {
                 HStack {
                     Spacer()
                     Button {
-                        onAdd?()
+                        self.onAdd?()
                     } label: {
                         Label("Add Server", systemImage: "plus")
                     }
@@ -367,30 +371,30 @@ struct MCPServersTabView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-                    if !servers.isEmpty {
+                    if !self.servers.isEmpty {
                         SourceLegend()
                     }
 
-                    if servers.isEmpty {
+                    if self.servers.isEmpty {
                         ContentUnavailableView(
                             "No MCP Servers",
                             systemImage: "server.rack",
-                            description: Text(emptyMessage)
+                            description: Text(self.emptyMessage)
                         )
                     } else {
-                        ForEach(Array(servers.enumerated()), id: \.offset) { _, item in
+                        ForEach(Array(self.servers.enumerated()), id: \.offset) { _, item in
                             MCPServerCard(
                                 name: item.name,
                                 server: item.server,
                                 source: item.source,
-                                onEdit: onEdit != nil ? {
-                                    onEdit?(item.name, item.server, item.source)
+                                onEdit: self.onEdit != nil ? {
+                                    self.onEdit?(item.name, item.server, item.source)
                                 } : nil,
-                                onDelete: onDelete != nil ? {
-                                    onDelete?(item.name, item.source)
+                                onDelete: self.onDelete != nil ? {
+                                    self.onDelete?(item.name, item.source)
                                 } : nil,
-                                onCopy: onCopy != nil ? {
-                                    onCopy?(item.name, item.server)
+                                onCopy: self.onCopy != nil ? {
+                                    self.onCopy?(item.name, item.server)
                                 } : nil
                             )
                         }
@@ -423,13 +427,13 @@ struct MCPServerCard: View {
             VStack(alignment: .leading, spacing: 8) {
                 // Header
                 HStack {
-                    Image(systemName: server.isHTTP ? "globe" : "terminal")
-                        .foregroundStyle(server.isHTTP ? .blue : .green)
+                    Image(systemName: self.server.isHTTP ? "globe" : "terminal")
+                        .foregroundStyle(self.server.isHTTP ? .blue : .green)
 
-                    Text(name)
+                    Text(self.name)
                         .font(.headline)
 
-                    Text(server.isHTTP ? "HTTP" : "Stdio")
+                    Text(self.server.isHTTP ? "HTTP" : "Stdio")
                         .font(.caption)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
@@ -440,47 +444,47 @@ struct MCPServerCard: View {
                     // Action buttons
                     HStack(spacing: 4) {
                         // Health check button
-                        MCPHealthCheckButton(serverName: name, server: server)
+                        MCPHealthCheckButton(serverName: self.name, server: self.server)
 
                         // Copy to clipboard
                         Button {
-                            copyToClipboard()
+                            self.copyToClipboard()
                         } label: {
                             Image(systemName: "doc.on.doc")
                                 .font(.caption)
                         }
                         .buttonStyle(.plain)
                         .help("Copy as JSON")
-                        .accessibilityLabel("Copy \(name) as JSON")
+                        .accessibilityLabel("Copy \(self.name) as JSON")
 
                         // Copy to project
-                        if onCopy != nil {
+                        if self.onCopy != nil {
                             Button {
-                                onCopy?()
+                                self.onCopy?()
                             } label: {
                                 Image(systemName: "arrow.right.doc.on.clipboard")
                                     .font(.caption)
                             }
                             .buttonStyle(.plain)
                             .help("Copy to...")
-                            .accessibilityLabel("Copy \(name) to another project")
+                            .accessibilityLabel("Copy \(self.name) to another project")
                         }
 
-                        if onEdit != nil {
+                        if self.onEdit != nil {
                             Button {
-                                onEdit?()
+                                self.onEdit?()
                             } label: {
                                 Image(systemName: "pencil")
                                     .font(.caption)
                             }
                             .buttonStyle(.plain)
                             .help("Edit server")
-                            .accessibilityLabel("Edit \(name)")
+                            .accessibilityLabel("Edit \(self.name)")
                         }
 
-                        if onDelete != nil {
+                        if self.onDelete != nil {
                             Button {
-                                onDelete?()
+                                self.onDelete?()
                             } label: {
                                 Image(systemName: "trash")
                                     .font(.caption)
@@ -488,26 +492,27 @@ struct MCPServerCard: View {
                             }
                             .buttonStyle(.plain)
                             .help("Delete server")
-                            .accessibilityLabel("Delete \(name)")
+                            .accessibilityLabel("Delete \(self.name)")
                         }
                     }
 
-                    SourceBadge(source: source)
+                    SourceBadge(source: self.source)
 
                     Button {
                         withAnimation {
-                            isExpanded.toggle()
+                            self.isExpanded.toggle()
                         }
                     } label: {
-                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        Image(systemName: self.isExpanded ? "chevron.up" : "chevron.down")
                             .font(.caption)
                     }
                     .buttonStyle(.plain)
-                    .accessibilityLabel(isExpanded ? "Collapse \(name) details" : "Expand \(name) details")
+                    .accessibilityLabel(self
+                        .isExpanded ? "Collapse \(self.name) details" : "Expand \(self.name) details")
                 }
 
                 // Summary line
-                if server.isHTTP {
+                if self.server.isHTTP {
                     if let url = server.url {
                         Text(url)
                             .font(.system(.caption, design: .monospaced))
@@ -528,10 +533,10 @@ struct MCPServerCard: View {
                 }
 
                 // Expanded details
-                if isExpanded {
+                if self.isExpanded {
                     Divider()
 
-                    if server.isHTTP {
+                    if self.server.isHTTP {
                         if let headers = server.headers, !headers.isEmpty {
                             Text("Headers:")
                                 .font(.caption)
@@ -542,7 +547,7 @@ struct MCPServerCard: View {
                                         .font(.system(.caption, design: .monospaced))
                                     Text(":")
                                         .foregroundStyle(.secondary)
-                                    Text(maskSensitiveValue(key: key, value: headers[key] ?? ""))
+                                    Text(self.maskSensitiveValue(key: key, value: headers[key] ?? ""))
                                         .font(.system(.caption, design: .monospaced))
                                         .foregroundStyle(.secondary)
                                 }
@@ -559,7 +564,7 @@ struct MCPServerCard: View {
                                         .font(.system(.caption, design: .monospaced))
                                     Text("=")
                                         .foregroundStyle(.secondary)
-                                    Text(maskSensitiveValue(key: key, value: env[key] ?? ""))
+                                    Text(self.maskSensitiveValue(key: key, value: env[key] ?? ""))
                                         .font(.system(.caption, design: .monospaced))
                                         .foregroundStyle(.secondary)
                                 }
@@ -571,14 +576,14 @@ struct MCPServerCard: View {
         }
         .contextMenu {
             Button {
-                copyToClipboard()
+                self.copyToClipboard()
             } label: {
                 Label("Copy as JSON", systemImage: "doc.on.doc")
             }
 
-            if onCopy != nil {
+            if self.onCopy != nil {
                 Button {
-                    onCopy?()
+                    self.onCopy?()
                 } label: {
                     Label("Copy to...", systemImage: "arrow.right.doc.on.clipboard")
                 }
@@ -586,18 +591,18 @@ struct MCPServerCard: View {
 
             Divider()
 
-            if onEdit != nil {
+            if self.onEdit != nil {
                 Button {
-                    onEdit?()
+                    self.onEdit?()
                 } label: {
                     Label("Edit", systemImage: "pencil")
                 }
             }
 
-            if onDelete != nil {
+            if self.onDelete != nil {
                 Divider()
                 Button(role: .destructive) {
-                    onDelete?()
+                    self.onDelete?()
                 } label: {
                     Label("Delete", systemImage: "trash")
                 }
@@ -627,7 +632,10 @@ struct MCPServerCard: View {
         {
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(jsonString, forType: .string)
-            NotificationManager.shared.showSuccess("Copied to clipboard", message: "Server '\(name)' copied as JSON")
+            NotificationManager.shared.showSuccess(
+                "Copied to clipboard",
+                message: "Server '\(self.name)' copied as JSON"
+            )
         }
     }
 }
@@ -647,7 +655,7 @@ struct HooksTabView: View {
             VStack(alignment: .leading, spacing: 16) {
                 SourceLegend()
 
-                if allHooksEmpty {
+                if self.allHooksEmpty {
                     ContentUnavailableView(
                         "No Hooks Configured",
                         systemImage: "arrow.triangle.branch",
@@ -657,12 +665,12 @@ struct HooksTabView: View {
                     )
                 } else {
                     // List all hook events
-                    ForEach(allHookEvents, id: \.self) { event in
+                    ForEach(self.allHookEvents, id: \.self) { event in
                         HookEventSection(
                             event: event,
-                            globalGroups: globalHooks?[event],
-                            projectGroups: projectHooks?[event],
-                            localGroups: localHooks?[event]
+                            globalGroups: self.globalHooks?[event],
+                            projectGroups: self.projectHooks?[event],
+                            localGroups: self.localHooks?[event]
                         )
                     }
                 }
@@ -676,9 +684,9 @@ struct HooksTabView: View {
     // MARK: Private
 
     private var allHooksEmpty: Bool {
-        (globalHooks?.isEmpty ?? true) &&
-            (projectHooks?.isEmpty ?? true) &&
-            (localHooks?.isEmpty ?? true)
+        (self.globalHooks?.isEmpty ?? true) &&
+            (self.projectHooks?.isEmpty ?? true) &&
+            (self.localHooks?.isEmpty ?? true)
     }
 
     private var allHookEvents: [String] {
@@ -708,7 +716,7 @@ struct HookEventSection: View {
     var body: some View {
         GroupBox {
             VStack(alignment: .leading, spacing: 8) {
-                Text(event)
+                Text(self.event)
                     .font(.headline)
 
                 // Global hooks
@@ -753,7 +761,7 @@ struct HookGroupRow: View {
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
-                SourceBadge(source: source)
+                SourceBadge(source: self.source)
             }
 
             if let hooks = group.hooks {

--- a/Fig/Sources/Views/EffectiveConfigView.swift
+++ b/Fig/Sources/Views/EffectiveConfigView.swift
@@ -16,12 +16,12 @@ struct EffectiveConfigView: View {
             HStack {
                 Spacer()
 
-                Toggle("View as JSON", isOn: $showJSON)
+                Toggle("View as JSON", isOn: self.$showJSON)
                     .toggleStyle(.switch)
                     .controlSize(.small)
 
                 Button {
-                    exportToClipboard()
+                    self.exportToClipboard()
                 } label: {
                     Label("Copy to Clipboard", systemImage: "doc.on.clipboard")
                 }
@@ -33,12 +33,12 @@ struct EffectiveConfigView: View {
 
             Divider()
 
-            if showJSON {
-                EffectiveConfigJSONView(mergedSettings: mergedSettings)
+            if self.showJSON {
+                EffectiveConfigJSONView(mergedSettings: self.mergedSettings)
             } else {
                 EffectiveConfigStructuredView(
-                    mergedSettings: mergedSettings,
-                    envOverrides: envOverrides
+                    mergedSettings: self.mergedSettings,
+                    envOverrides: self.envOverrides
                 )
             }
         }
@@ -49,7 +49,7 @@ struct EffectiveConfigView: View {
     @State private var showJSON = false
 
     private func exportToClipboard() {
-        let json = EffectiveConfigSerializer.toJSON(mergedSettings)
+        let json = EffectiveConfigSerializer.toJSON(self.mergedSettings)
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(json, forType: .string)
         NotificationManager.shared.showSuccess(
@@ -71,11 +71,11 @@ struct EffectiveConfigStructuredView: View {
             VStack(alignment: .leading, spacing: 20) {
                 SourceLegend()
 
-                EffectivePermissionsSection(permissions: mergedSettings.permissions)
-                EffectiveEnvSection(env: mergedSettings.env, overrides: envOverrides)
-                EffectiveHooksSection(hooks: mergedSettings.hooks)
-                EffectiveDisallowedToolsSection(tools: mergedSettings.disallowedTools)
-                EffectiveAttributionSection(attribution: mergedSettings.attribution)
+                EffectivePermissionsSection(permissions: self.mergedSettings.permissions)
+                EffectiveEnvSection(env: self.mergedSettings.env, overrides: self.envOverrides)
+                EffectiveHooksSection(hooks: self.mergedSettings.hooks)
+                EffectiveDisallowedToolsSection(tools: self.mergedSettings.disallowedTools)
+                EffectiveAttributionSection(attribution: self.mergedSettings.attribution)
 
                 Spacer()
             }
@@ -91,7 +91,7 @@ struct EffectiveConfigJSONView: View {
     let mergedSettings: MergedSettings
 
     var body: some View {
-        let jsonString = EffectiveConfigSerializer.toJSON(mergedSettings)
+        let jsonString = EffectiveConfigSerializer.toJSON(self.mergedSettings)
         ScrollView {
             Text(jsonString)
                 .font(.system(.body, design: .monospaced))
@@ -111,19 +111,19 @@ struct EffectivePermissionsSection: View {
 
     var body: some View {
         GroupBox("Permissions") {
-            if permissions.allow.isEmpty, permissions.deny.isEmpty {
+            if self.permissions.allow.isEmpty, self.permissions.deny.isEmpty {
                 Text("No permission rules configured.")
                     .foregroundStyle(.secondary)
                     .padding(.vertical, 8)
             } else {
                 VStack(alignment: .leading, spacing: 8) {
-                    if !permissions.allow.isEmpty {
+                    if !self.permissions.allow.isEmpty {
                         Label("Allow", systemImage: "checkmark.circle.fill")
                             .font(.subheadline)
                             .fontWeight(.medium)
                             .foregroundStyle(.green)
 
-                        ForEach(Array(permissions.allow.enumerated()), id: \.offset) { _, entry in
+                        ForEach(Array(self.permissions.allow.enumerated()), id: \.offset) { _, entry in
                             EffectiveRuleRow(
                                 rule: entry.value,
                                 source: entry.source,
@@ -133,17 +133,17 @@ struct EffectivePermissionsSection: View {
                         }
                     }
 
-                    if !permissions.allow.isEmpty, !permissions.deny.isEmpty {
+                    if !self.permissions.allow.isEmpty, !self.permissions.deny.isEmpty {
                         Divider()
                     }
 
-                    if !permissions.deny.isEmpty {
+                    if !self.permissions.deny.isEmpty {
                         Label("Deny", systemImage: "xmark.circle.fill")
                             .font(.subheadline)
                             .fontWeight(.medium)
                             .foregroundStyle(.red)
 
-                        ForEach(Array(permissions.deny.enumerated()), id: \.offset) { _, entry in
+                        ForEach(Array(self.permissions.deny.enumerated()), id: \.offset) { _, entry in
                             EffectiveRuleRow(
                                 rule: entry.value,
                                 source: entry.source,
@@ -168,19 +168,19 @@ struct EffectiveEnvSection: View {
 
     var body: some View {
         GroupBox("Environment Variables") {
-            if env.isEmpty {
+            if self.env.isEmpty {
                 Text("No environment variables configured.")
                     .foregroundStyle(.secondary)
                     .padding(.vertical, 8)
             } else {
                 VStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(env.keys.sorted().enumerated()), id: \.offset) { index, key in
+                    ForEach(Array(self.env.keys.sorted().enumerated()), id: \.offset) { index, key in
                         if index > 0 {
                             Divider()
                         }
 
-                        let entry = env[key]!
-                        let keyOverrides = overrides[key]
+                        let entry = self.env[key]!
+                        let keyOverrides = self.overrides[key]
 
                         EffectiveEnvRow(
                             key: key,
@@ -204,13 +204,13 @@ struct EffectiveHooksSection: View {
 
     var body: some View {
         GroupBox("Hooks") {
-            if hooks.eventNames.isEmpty {
+            if self.hooks.eventNames.isEmpty {
                 Text("No hooks configured.")
                     .foregroundStyle(.secondary)
                     .padding(.vertical, 8)
             } else {
                 VStack(alignment: .leading, spacing: 12) {
-                    ForEach(hooks.eventNames, id: \.self) { event in
+                    ForEach(self.hooks.eventNames, id: \.self) { event in
                         if let groups = hooks.groups(for: event) {
                             EffectiveHookEventView(event: event, groups: groups)
                         }
@@ -231,11 +231,11 @@ struct EffectiveHookEventView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(event)
+            Text(self.event)
                 .font(.subheadline)
                 .fontWeight(.medium)
 
-            ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
+            ForEach(Array(self.groups.enumerated()), id: \.offset) { _, group in
                 HStack {
                     VStack(alignment: .leading, spacing: 2) {
                         if let matcher = group.value.matcher {
@@ -274,13 +274,13 @@ struct EffectiveDisallowedToolsSection: View {
 
     var body: some View {
         GroupBox("Disallowed Tools") {
-            if tools.isEmpty {
+            if self.tools.isEmpty {
                 Text("No tools are disallowed.")
                     .foregroundStyle(.secondary)
                     .padding(.vertical, 8)
             } else {
                 VStack(alignment: .leading, spacing: 4) {
-                    ForEach(Array(tools.enumerated()), id: \.offset) { _, entry in
+                    ForEach(Array(self.tools.enumerated()), id: \.offset) { _, entry in
                         HStack {
                             Image(systemName: "xmark.circle.fill")
                                 .foregroundStyle(.red)
@@ -347,15 +347,15 @@ struct EffectiveRuleRow: View {
 
     var body: some View {
         HStack {
-            Image(systemName: icon)
-                .foregroundStyle(iconColor)
+            Image(systemName: self.icon)
+                .foregroundStyle(self.iconColor)
                 .frame(width: 20)
-            Text(rule)
+            Text(self.rule)
                 .font(.system(.body, design: .monospaced))
                 .lineLimit(1)
                 .truncationMode(.middle)
             Spacer()
-            SourceBadge(source: source)
+            SourceBadge(source: self.source)
         }
         .padding(.vertical, 2)
     }
@@ -375,21 +375,21 @@ struct EffectiveEnvRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             EffectiveEnvValueRow(
-                key: key,
-                value: effectiveValue,
-                source: effectiveSource,
-                isSensitive: isSensitive,
-                isValueVisible: $isValueVisible
+                key: self.key,
+                value: self.effectiveValue,
+                source: self.effectiveSource,
+                isSensitive: self.isSensitive,
+                isValueVisible: self.$isValueVisible
             )
 
-            if !overriddenEntries.isEmpty {
-                ForEach(Array(overriddenEntries.enumerated()), id: \.offset) { _, entry in
+            if !self.overriddenEntries.isEmpty {
+                ForEach(Array(self.overriddenEntries.enumerated()), id: \.offset) { _, entry in
                     EffectiveEnvOverriddenRow(
-                        key: key,
+                        key: self.key,
                         value: entry.value,
                         source: entry.source,
-                        isSensitive: isSensitive,
-                        isValueVisible: isValueVisible
+                        isSensitive: self.isSensitive,
+                        isValueVisible: self.isValueVisible
                     )
                 }
             }
@@ -403,7 +403,7 @@ struct EffectiveEnvRow: View {
 
     private var isSensitive: Bool {
         let sensitivePatterns = ["token", "key", "secret", "password", "credential", "api"]
-        let lowercaseKey = key.lowercased()
+        let lowercaseKey = self.key.lowercased()
         return sensitivePatterns.contains { lowercaseKey.contains($0) }
     }
 }
@@ -416,11 +416,12 @@ struct EffectiveEnvValueRow: View {
     let value: String
     let source: ConfigSource
     let isSensitive: Bool
+
     @Binding var isValueVisible: Bool
 
     var body: some View {
         HStack(alignment: .top) {
-            Text(key)
+            Text(self.key)
                 .font(.system(.body, design: .monospaced))
                 .fontWeight(.medium)
                 .frame(minWidth: 200, alignment: .leading)
@@ -429,29 +430,29 @@ struct EffectiveEnvValueRow: View {
                 .foregroundStyle(.secondary)
 
             Group {
-                if isValueVisible || !isSensitive {
-                    Text(value)
+                if self.isValueVisible || !self.isSensitive {
+                    Text(self.value)
                         .font(.system(.body, design: .monospaced))
                         .lineLimit(2)
                         .truncationMode(.middle)
                 } else {
-                    Text(String(repeating: "\u{2022}", count: min(value.count, 20)))
+                    Text(String(repeating: "\u{2022}", count: min(self.value.count, 20)))
                         .font(.system(.body, design: .monospaced))
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            if isSensitive {
+            if self.isSensitive {
                 Button {
-                    isValueVisible.toggle()
+                    self.isValueVisible.toggle()
                 } label: {
-                    Image(systemName: isValueVisible ? "eye.slash" : "eye")
+                    Image(systemName: self.isValueVisible ? "eye.slash" : "eye")
                         .font(.caption)
                 }
                 .buttonStyle(.plain)
             }
 
-            SourceBadge(source: source)
+            SourceBadge(source: self.source)
         }
     }
 }
@@ -468,7 +469,7 @@ struct EffectiveEnvOverriddenRow: View {
 
     var body: some View {
         HStack(alignment: .top) {
-            Text(key)
+            Text(self.key)
                 .font(.system(.caption, design: .monospaced))
                 .strikethrough()
                 .foregroundStyle(.secondary)
@@ -479,14 +480,14 @@ struct EffectiveEnvOverriddenRow: View {
                 .font(.caption)
 
             Group {
-                if isValueVisible || !isSensitive {
-                    Text(value)
+                if self.isValueVisible || !self.isSensitive {
+                    Text(self.value)
                         .font(.system(.caption, design: .monospaced))
                         .strikethrough()
                         .lineLimit(1)
                         .truncationMode(.middle)
                 } else {
-                    Text(String(repeating: "\u{2022}", count: min(value.count, 20)))
+                    Text(String(repeating: "\u{2022}", count: min(self.value.count, 20)))
                         .font(.system(.caption, design: .monospaced))
                         .strikethrough()
                 }
@@ -499,7 +500,7 @@ struct EffectiveEnvOverriddenRow: View {
                 .foregroundStyle(.orange)
                 .italic()
 
-            SourceBadge(source: source)
+            SourceBadge(source: self.source)
         }
         .padding(.leading, 8)
     }
@@ -509,19 +510,25 @@ struct EffectiveEnvOverriddenRow: View {
 
 /// Serializes merged settings to JSON format.
 enum EffectiveConfigSerializer {
+    // MARK: Internal
+
     static func toJSON(_ settings: MergedSettings) -> String {
         var result: [String: Any] = [:]
 
-        result["permissions"] = permissionsDict(settings.permissions)
-        result["env"] = envDict(settings)
-        result["hooks"] = hooksDict(settings.hooks)
-        result["disallowedTools"] = toolsArray(settings)
-        result["attribution"] = attributionDict(settings.attribution)
+        result["permissions"] = self.permissionsDict(settings.permissions)
+        result["env"] = self.envDict(settings)
+        result["hooks"] = self.hooksDict(settings.hooks)
+        result["disallowedTools"] = self.toolsArray(settings)
+        result["attribution"] = self.attributionDict(settings.attribution)
 
         // Remove nil/empty entries
         result = result.compactMapValues { value in
-            if let dict = value as? [String: Any], dict.isEmpty { return nil }
-            if let arr = value as? [Any], arr.isEmpty { return nil }
+            if let dict = value as? [String: Any], dict.isEmpty {
+                return nil
+            }
+            if let arr = value as? [Any], arr.isEmpty {
+                return nil
+            }
             return value
         }
 
@@ -542,8 +549,12 @@ enum EffectiveConfigSerializer {
         var perms: [String: Any] = [:]
         let allow = permissions.allowPatterns
         let deny = permissions.denyPatterns
-        if !allow.isEmpty { perms["allow"] = allow }
-        if !deny.isEmpty { perms["deny"] = deny }
+        if !allow.isEmpty {
+            perms["allow"] = allow
+        }
+        if !deny.isEmpty {
+            perms["deny"] = deny
+        }
         return perms.isEmpty ? nil : perms
     }
 
@@ -555,15 +566,23 @@ enum EffectiveConfigSerializer {
     private static func hooksDict(_ hooks: MergedHooks) -> [String: Any]? {
         var dict: [String: [[String: Any]]] = [:]
         for event in hooks.eventNames {
-            guard let groups = hooks.groups(for: event) else { continue }
+            guard let groups = hooks.groups(for: event) else {
+                continue
+            }
             dict[event] = groups.map { group in
                 var groupDict: [String: Any] = [:]
-                if let matcher = group.value.matcher { groupDict["matcher"] = matcher }
+                if let matcher = group.value.matcher {
+                    groupDict["matcher"] = matcher
+                }
                 if let hookDefs = group.value.hooks {
                     groupDict["hooks"] = hookDefs.map { hook in
                         var hookDict: [String: Any] = [:]
-                        if let type = hook.type { hookDict["type"] = type }
-                        if let command = hook.command { hookDict["command"] = command }
+                        if let type = hook.type {
+                            hookDict["type"] = type
+                        }
+                        if let command = hook.command {
+                            hookDict["command"] = command
+                        }
                         return hookDict
                     }
                 }
@@ -579,10 +598,16 @@ enum EffectiveConfigSerializer {
     }
 
     private static func attributionDict(_ attribution: MergedValue<Attribution>?) -> [String: Any]? {
-        guard let attr = attribution else { return nil }
+        guard let attr = attribution else {
+            return nil
+        }
         var dict: [String: Any] = [:]
-        if let commits = attr.value.commits { dict["commits"] = commits }
-        if let prs = attr.value.pullRequests { dict["pullRequests"] = prs }
+        if let commits = attr.value.commits {
+            dict["commits"] = commits
+        }
+        if let prs = attr.value.pullRequests {
+            dict["pullRequests"] = prs
+        }
         return dict.isEmpty ? nil : dict
     }
 }
@@ -593,18 +618,18 @@ enum EffectiveConfigSerializer {
             permissions: MergedPermissions(
                 allow: [
                     MergedValue(value: "Bash(npm run *)", source: .global),
-                    MergedValue(value: "Read(src/**)", source: .projectShared)
+                    MergedValue(value: "Read(src/**)", source: .projectShared),
                 ],
                 deny: [
-                    MergedValue(value: "Read(.env)", source: .projectLocal)
+                    MergedValue(value: "Read(.env)", source: .projectLocal),
                 ]
             ),
             env: [
                 "CLAUDE_CODE_MAX_OUTPUT_TOKENS": MergedValue(value: "16384", source: .projectLocal),
-                "ANTHROPIC_MODEL": MergedValue(value: "claude-sonnet-4-20250514", source: .global)
+                "ANTHROPIC_MODEL": MergedValue(value: "claude-sonnet-4-20250514", source: .global),
             ],
             disallowedTools: [
-                MergedValue(value: "WebFetch", source: .projectShared)
+                MergedValue(value: "WebFetch", source: .projectShared),
             ],
             attribution: MergedValue(
                 value: Attribution(commits: true, pullRequests: false),
@@ -614,8 +639,8 @@ enum EffectiveConfigSerializer {
         envOverrides: [
             "CLAUDE_CODE_MAX_OUTPUT_TOKENS": [
                 ("8192", .global),
-                ("16384", .projectLocal)
-            ]
+                ("16384", .projectLocal),
+            ],
         ]
     )
     .padding()

--- a/Fig/Sources/Views/EnvironmentEditorViews.swift
+++ b/Fig/Sources/Views/EnvironmentEditorViews.swift
@@ -13,14 +13,14 @@ struct EnvironmentVariableEditorView: View {
             VStack(alignment: .leading, spacing: 16) {
                 // Target selector and add button
                 HStack {
-                    if !viewModel.isGlobalMode {
-                        EditingTargetPicker(selection: $viewModel.editingTarget)
+                    if !self.viewModel.isGlobalMode {
+                        EditingTargetPicker(selection: self.$viewModel.editingTarget)
                     }
 
                     Spacer()
 
                     Button {
-                        showingAddVariable = true
+                        self.showingAddVariable = true
                     } label: {
                         Label("Add Variable", systemImage: "plus")
                     }
@@ -32,9 +32,9 @@ struct EnvironmentVariableEditorView: View {
                         ForEach(KnownEnvironmentVariable.allVariables) { variable in
                             KnownVariableRow(
                                 variable: variable,
-                                isAdded: viewModel.environmentVariables.contains { $0.key == variable.name }
+                                isAdded: self.viewModel.environmentVariables.contains { $0.key == variable.name }
                             ) {
-                                showingAddVariable = true
+                                self.showingAddVariable = true
                             }
                         }
                     }
@@ -71,31 +71,32 @@ struct EnvironmentVariableEditorView: View {
 
                         Divider()
 
-                        if viewModel.environmentVariables.isEmpty {
+                        if self.viewModel.environmentVariables.isEmpty {
                             Text("No environment variables configured.")
                                 .foregroundStyle(.secondary)
                                 .padding(.vertical, 16)
                                 .frame(maxWidth: .infinity, alignment: .center)
                         } else {
-                            ForEach(viewModel.environmentVariables) { envVar in
+                            ForEach(self.viewModel.environmentVariables) { envVar in
                                 EditableEnvironmentVariableRow(
                                     envVar: envVar,
                                     description: KnownEnvironmentVariable.description(for: envVar.key),
                                     onUpdate: { newKey, newValue in
-                                        viewModel.updateEnvironmentVariable(
+                                        self.viewModel.updateEnvironmentVariable(
                                             envVar,
                                             newKey: newKey,
                                             newValue: newValue
                                         )
                                     },
                                     onDelete: {
-                                        viewModel.removeEnvironmentVariable(envVar)
+                                        self.viewModel.removeEnvironmentVariable(envVar)
                                     },
                                     isDuplicateKey: { key in
-                                        key != envVar.key && viewModel.environmentVariables.contains { $0.key == key }
+                                        key != envVar.key && self.viewModel.environmentVariables
+                                            .contains { $0.key == key }
                                     }
                                 )
-                                if envVar.id != viewModel.environmentVariables.last?.id {
+                                if envVar.id != self.viewModel.environmentVariables.last?.id {
                                     Divider()
                                 }
                             }
@@ -108,11 +109,11 @@ struct EnvironmentVariableEditorView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .sheet(isPresented: $showingAddVariable) {
+        .sheet(isPresented: self.$showingAddVariable) {
             AddEnvironmentVariableSheet { key, value in
-                viewModel.addEnvironmentVariable(key: key, value: value)
+                self.viewModel.addEnvironmentVariable(key: key, value: value)
             } isDuplicateKey: { key in
-                viewModel.environmentVariables.contains { $0.key == key }
+                self.viewModel.environmentVariables.contains { $0.key == key }
             }
         }
     }
@@ -133,20 +134,20 @@ struct KnownVariableRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             HStack {
-                Text(variable.name)
+                Text(self.variable.name)
                     .font(.system(.caption, design: .monospaced))
                     .fontWeight(.medium)
 
                 Button {
-                    onAddTapped()
+                    self.onAddTapped()
                 } label: {
                     Image(systemName: "plus.circle")
                         .font(.caption)
                 }
                 .buttonStyle(.plain)
-                .disabled(isAdded)
+                .disabled(self.isAdded)
             }
-            Text(variable.description)
+            Text(self.variable.description)
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
@@ -167,25 +168,25 @@ struct EditableEnvironmentVariableRow: View {
 
     var body: some View {
         HStack(alignment: .top) {
-            if isEditing {
-                editingContent
+            if self.isEditing {
+                self.editingContent
             } else {
-                displayContent
+                self.displayContent
             }
         }
         .padding(.vertical, 8)
         .padding(.horizontal, 8)
         .confirmationDialog(
             "Delete Variable",
-            isPresented: $showingDeleteConfirmation,
+            isPresented: self.$showingDeleteConfirmation,
             titleVisibility: .visible
         ) {
             Button("Delete", role: .destructive) {
-                onDelete()
+                self.onDelete()
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("Are you sure you want to delete \(envVar.key)?")
+            Text("Are you sure you want to delete \(self.envVar.key)?")
         }
     }
 
@@ -199,33 +200,33 @@ struct EditableEnvironmentVariableRow: View {
 
     private var isSensitive: Bool {
         let sensitivePatterns = ["token", "key", "secret", "password", "credential", "api"]
-        let lowercaseKey = envVar.key.lowercased()
+        let lowercaseKey = self.envVar.key.lowercased()
         return sensitivePatterns.contains { lowercaseKey.contains($0) }
     }
 
     private var canSave: Bool {
-        !editedKey.isEmpty && !isDuplicateKey(editedKey)
+        !self.editedKey.isEmpty && !self.isDuplicateKey(self.editedKey)
     }
 
     @ViewBuilder private var editingContent: some View {
-        TextField("Key", text: $editedKey)
+        TextField("Key", text: self.$editedKey)
             .textFieldStyle(.roundedBorder)
             .font(.system(.body, design: .monospaced))
             .frame(minWidth: 200, alignment: .leading)
 
-        TextField("Value", text: $editedValue)
+        TextField("Value", text: self.$editedValue)
             .textFieldStyle(.roundedBorder)
             .font(.system(.body, design: .monospaced))
             .frame(maxWidth: .infinity)
 
         HStack(spacing: 4) {
             Button("Save") {
-                saveEdit()
+                self.saveEdit()
             }
-            .disabled(!canSave)
+            .disabled(!self.canSave)
 
             Button("Cancel") {
-                cancelEdit()
+                self.cancelEdit()
             }
         }
         .frame(width: 120)
@@ -233,7 +234,7 @@ struct EditableEnvironmentVariableRow: View {
 
     @ViewBuilder private var displayContent: some View {
         VStack(alignment: .leading, spacing: 2) {
-            Text(envVar.key)
+            Text(self.envVar.key)
                 .font(.system(.body, design: .monospaced))
                 .fontWeight(.medium)
             if let description {
@@ -248,11 +249,11 @@ struct EditableEnvironmentVariableRow: View {
             .foregroundStyle(.secondary)
 
         Group {
-            if isValueVisible || !isSensitive {
-                Text(envVar.value)
+            if self.isValueVisible || !self.isSensitive {
+                Text(self.envVar.value)
                     .font(.system(.body, design: .monospaced))
             } else {
-                Text(String(repeating: "\u{2022}", count: min(envVar.value.count, 20)))
+                Text(String(repeating: "\u{2022}", count: min(self.envVar.value.count, 20)))
                     .font(.system(.body, design: .monospaced))
             }
         }
@@ -260,18 +261,18 @@ struct EditableEnvironmentVariableRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
 
         HStack(spacing: 8) {
-            if isSensitive {
+            if self.isSensitive {
                 Button {
-                    isValueVisible.toggle()
+                    self.isValueVisible.toggle()
                 } label: {
-                    Image(systemName: isValueVisible ? "eye.slash" : "eye")
+                    Image(systemName: self.isValueVisible ? "eye.slash" : "eye")
                         .font(.caption)
                 }
                 .buttonStyle(.plain)
             }
 
             Button {
-                startEditing()
+                self.startEditing()
             } label: {
                 Image(systemName: "pencil")
                     .font(.caption)
@@ -279,7 +280,7 @@ struct EditableEnvironmentVariableRow: View {
             .buttonStyle(.plain)
 
             Button {
-                showingDeleteConfirmation = true
+                self.showingDeleteConfirmation = true
             } label: {
                 Image(systemName: "trash")
                     .font(.caption)
@@ -291,21 +292,23 @@ struct EditableEnvironmentVariableRow: View {
     }
 
     private func startEditing() {
-        editedKey = envVar.key
-        editedValue = envVar.value
-        isEditing = true
+        self.editedKey = self.envVar.key
+        self.editedValue = self.envVar.value
+        self.isEditing = true
     }
 
     private func saveEdit() {
-        guard canSave else { return }
-        onUpdate(editedKey, editedValue)
-        isEditing = false
+        guard self.canSave else {
+            return
+        }
+        self.onUpdate(self.editedKey, self.editedValue)
+        self.isEditing = false
     }
 
     private func cancelEdit() {
-        isEditing = false
-        editedKey = envVar.key
-        editedValue = envVar.value
+        self.isEditing = false
+        self.editedKey = self.envVar.key
+        self.editedValue = self.envVar.value
     }
 }
 
@@ -337,13 +340,13 @@ struct AddEnvironmentVariableSheet: View {
                 Text("Key")
                     .font(.headline)
 
-                TextField("VARIABLE_NAME", text: $key)
+                TextField("VARIABLE_NAME", text: self.$key)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
 
                 // Autocomplete suggestions
-                if !key.isEmpty {
-                    autocompleteView
+                if !self.key.isEmpty {
+                    self.autocompleteView
                 }
 
                 // Show description for known variables
@@ -359,7 +362,7 @@ struct AddEnvironmentVariableSheet: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Value")
                     .font(.headline)
-                TextField("value", text: $value)
+                TextField("value", text: self.$value)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
             }
@@ -380,18 +383,18 @@ struct AddEnvironmentVariableSheet: View {
             // Buttons
             HStack {
                 Button("Cancel") {
-                    dismiss()
+                    self.dismiss()
                 }
                 .keyboardShortcut(.cancelAction)
 
                 Spacer()
 
                 Button("Add Variable") {
-                    onAdd(key, value)
-                    dismiss()
+                    self.onAdd(self.key, self.value)
+                    self.dismiss()
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(!isValid)
+                .disabled(!self.isValid)
             }
         }
         .padding()
@@ -406,16 +409,33 @@ struct AddEnvironmentVariableSheet: View {
     @State private var key = ""
     @State private var value = ""
 
+    private var validationError: String? {
+        if self.key.isEmpty {
+            return nil // Don't show error until they try to submit
+        }
+        if self.isDuplicateKey(self.key) {
+            return "A variable with this key already exists"
+        }
+        if self.key.contains(" ") {
+            return "Key cannot contain spaces"
+        }
+        return nil
+    }
+
+    private var isValid: Bool {
+        !self.key.isEmpty && !self.isDuplicateKey(self.key) && !self.key.contains(" ")
+    }
+
     @ViewBuilder private var autocompleteView: some View {
         let suggestions = KnownEnvironmentVariable.allVariables.filter {
-            $0.name.localizedCaseInsensitiveContains(key)
+            $0.name.localizedCaseInsensitiveContains(self.key)
         }
         if !suggestions.isEmpty {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 8) {
                     ForEach(suggestions) { variable in
                         Button {
-                            key = variable.name
+                            self.key = variable.name
                         } label: {
                             Text(variable.name)
                                 .font(.caption)
@@ -429,30 +449,13 @@ struct AddEnvironmentVariableSheet: View {
             }
         }
     }
-
-    private var validationError: String? {
-        if key.isEmpty {
-            return nil // Don't show error until they try to submit
-        }
-        if isDuplicateKey(key) {
-            return "A variable with this key already exists"
-        }
-        if key.contains(" ") {
-            return "Key cannot contain spaces"
-        }
-        return nil
-    }
-
-    private var isValid: Bool {
-        !key.isEmpty && !isDuplicateKey(key) && !key.contains(" ")
-    }
 }
 
 #Preview("Environment Variable Editor") {
     let viewModel = SettingsEditorViewModel(projectPath: "/Users/test/project")
     viewModel.environmentVariables = [
         EditableEnvironmentVariable(key: "CLAUDE_CODE_MAX_OUTPUT_TOKENS", value: "16384"),
-        EditableEnvironmentVariable(key: "API_KEY", value: "sk-1234567890")
+        EditableEnvironmentVariable(key: "API_KEY", value: "sk-1234567890"),
     ]
 
     return EnvironmentVariableEditorView(viewModel: viewModel)

--- a/Fig/Sources/Views/GlobalSettingsDetailView.swift
+++ b/Fig/Sources/Views/GlobalSettingsDetailView.swift
@@ -139,7 +139,7 @@ struct GlobalSettingsDetailView: View {
         VStack(spacing: 0) {
             // Header
             GlobalSettingsHeaderView(viewModel: self.viewModel) {
-                showingEditor = true
+                self.showingEditor = true
             }
 
             Divider()
@@ -166,7 +166,7 @@ struct GlobalSettingsDetailView: View {
         .task {
             await self.viewModel.load()
         }
-        .sheet(isPresented: $showingEditor) {
+        .sheet(isPresented: self.$showingEditor) {
             GlobalSettingsEditorView {
                 Task {
                     await self.viewModel.load()
@@ -212,6 +212,7 @@ struct GlobalSettingsDetailView: View {
 /// Header view for global settings.
 struct GlobalSettingsHeaderView: View {
     @Bindable var viewModel: GlobalSettingsViewModel
+
     var onEditSettings: (() -> Void)?
 
     var body: some View {
@@ -390,7 +391,7 @@ struct FileStatusBadge: View {
         .padding(.vertical, 4)
         .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(label), \(exists ? "file exists" : "file not found")")
+        .accessibilityLabel("\(self.label), \(self.exists ? "file exists" : "file not found")")
     }
 }
 

--- a/Fig/Sources/Views/MCPHealthCheckButton.swift
+++ b/Fig/Sources/Views/MCPHealthCheckButton.swift
@@ -11,28 +11,24 @@ struct MCPHealthCheckButton: View {
 
     var body: some View {
         Button {
-            runHealthCheck()
+            self.runHealthCheck()
         } label: {
             HStack(spacing: 4) {
-                statusIcon
+                self.statusIcon
                 Text("Test")
                     .font(.caption2)
             }
         }
         .buttonStyle(.bordered)
         .controlSize(.small)
-        .disabled(isChecking)
-        .help(helpText)
-        .popover(isPresented: $showDetails) {
-            HealthCheckResultPopover(result: result)
+        .disabled(self.isChecking)
+        .help(self.helpText)
+        .popover(isPresented: self.$showDetails) {
+            HealthCheckResultPopover(result: self.result)
         }
     }
 
     // MARK: Private
-
-    @State private var state: CheckState = .idle
-    @State private var result: MCPHealthCheckResult?
-    @State private var showDetails = false
 
     private enum CheckState {
         case idle
@@ -40,12 +36,16 @@ struct MCPHealthCheckButton: View {
         case completed
     }
 
+    @State private var state: CheckState = .idle
+    @State private var result: MCPHealthCheckResult?
+    @State private var showDetails = false
+
     private var isChecking: Bool {
-        state == .checking
+        self.state == .checking
     }
 
     private var helpText: String {
-        switch state {
+        switch self.state {
         case .idle:
             "Test server connection"
         case .checking:
@@ -60,7 +60,7 @@ struct MCPHealthCheckButton: View {
     }
 
     @ViewBuilder private var statusIcon: some View {
-        switch state {
+        switch self.state {
         case .idle:
             Image(systemName: "play.circle")
                 .foregroundStyle(.secondary)
@@ -89,27 +89,27 @@ struct MCPHealthCheckButton: View {
     }
 
     private func runHealthCheck() {
-        if state == .completed, result != nil {
+        if self.state == .completed, self.result != nil {
             // Show details if we already have a result
-            showDetails = true
+            self.showDetails = true
             return
         }
 
-        state = .checking
-        result = nil
+        self.state = .checking
+        self.result = nil
 
         Task {
             let checkResult = await MCPHealthCheckService.shared.checkHealth(
-                name: serverName,
-                server: server
+                name: self.serverName,
+                server: self.server
             )
-            result = checkResult
-            state = .completed
+            self.result = checkResult
+            self.state = .completed
 
             // Show toast notification
             switch checkResult.status {
             case let .success(info):
-                let name = info?.serverName ?? serverName
+                let name = info?.serverName ?? self.serverName
                 NotificationManager.shared.showSuccess(
                     "Connected to \(name)",
                     message: String(format: "Response time: %.0fms", checkResult.duration * 1000)
@@ -133,6 +133,8 @@ struct MCPHealthCheckButton: View {
 
 /// Popover showing detailed health check results.
 struct HealthCheckResultPopover: View {
+    // MARK: Internal
+
     let result: MCPHealthCheckResult?
 
     var body: some View {
@@ -140,9 +142,9 @@ struct HealthCheckResultPopover: View {
             if let result {
                 // Status header
                 HStack {
-                    statusIcon(for: result)
+                    self.statusIcon(for: result)
                     VStack(alignment: .leading) {
-                        Text(statusTitle(for: result))
+                        Text(self.statusTitle(for: result))
                             .font(.headline)
                         Text(String(format: "%.0fms", result.duration * 1000))
                             .font(.caption)
@@ -205,6 +207,8 @@ struct HealthCheckResultPopover: View {
         .frame(minWidth: 250, maxWidth: 350)
     }
 
+    // MARK: Private
+
     @ViewBuilder
     private func statusIcon(for result: MCPHealthCheckResult) -> some View {
         switch result.status {
@@ -244,10 +248,10 @@ private struct HealthCheckDetailRow: View {
 
     var body: some View {
         HStack {
-            Text(label + ":")
+            Text(self.label + ":")
                 .font(.caption)
                 .foregroundStyle(.secondary)
-            Text(value)
+            Text(self.value)
                 .font(.caption)
                 .fontWeight(.medium)
         }

--- a/Fig/Sources/Views/MCPServerEditorView.swift
+++ b/Fig/Sources/Views/MCPServerEditorView.swift
@@ -13,13 +13,11 @@ struct MCPServerEditorView: View {
     }
 
     @Bindable var viewModel: MCPServerEditorViewModel
-    @Environment(\.dismiss) private var dismiss
-    @FocusState private var focusedField: Field?
 
     var body: some View {
         VStack(spacing: 0) {
             // Header
-            header
+            self.header
 
             Divider()
 
@@ -27,20 +25,20 @@ struct MCPServerEditorView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
                     // Server identity section
-                    identitySection
+                    self.identitySection
 
                     // Target location section
-                    scopeSection
+                    self.scopeSection
 
                     // Type-specific configuration
-                    if viewModel.formData.serverType == .stdio {
-                        stdioSection
+                    if self.viewModel.formData.serverType == .stdio {
+                        self.stdioSection
                     } else {
-                        httpSection
+                        self.httpSection
                     }
 
                     // Import section
-                    importSection
+                    self.importSection
                 }
                 .padding()
             }
@@ -48,39 +46,46 @@ struct MCPServerEditorView: View {
             Divider()
 
             // Footer with buttons
-            footer
+            self.footer
         }
         .frame(width: 550, height: 600)
-        .onChange(of: viewModel.formData.name) { _, _ in viewModel.validate() }
-        .onChange(of: viewModel.formData.command) { _, _ in viewModel.validate() }
-        .onChange(of: viewModel.formData.url) { _, _ in viewModel.validate() }
-        .onChange(of: viewModel.formData.scope) { _, _ in viewModel.validate() }
+        .onChange(of: self.viewModel.formData.name) { _, _ in self.viewModel.validate() }
+        .onChange(of: self.viewModel.formData.command) { _, _ in self.viewModel.validate() }
+        .onChange(of: self.viewModel.formData.url) { _, _ in self.viewModel.validate() }
+        .onChange(of: self.viewModel.formData.scope) { _, _ in self.viewModel.validate() }
         .onAppear {
-            viewModel.validate()
-            focusedField = viewModel.isEditing ? .command : .name
+            self.viewModel.validate()
+            self.focusedField = self.viewModel.isEditing ? .command : .name
         }
     }
 
     // MARK: Private
 
-    @State private var showImportSheet = false
-    @State private var importText = ""
-    @State private var importType: ImportType = .json
-
     private enum ImportType: String, CaseIterable, Identifiable {
         case json = "JSON"
         case cli = "CLI Command"
 
-        var id: String { rawValue }
+        // MARK: Internal
+
+        var id: String {
+            rawValue
+        }
     }
+
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var focusedField: Field?
+
+    @State private var showImportSheet = false
+    @State private var importText = ""
+    @State private var importType: ImportType = .json
 
     private var header: some View {
         HStack {
-            Image(systemName: viewModel.formData.serverType.icon)
+            Image(systemName: self.viewModel.formData.serverType.icon)
                 .font(.title2)
-                .foregroundStyle(viewModel.formData.serverType == .http ? .blue : .green)
+                .foregroundStyle(self.viewModel.formData.serverType == .http ? .blue : .green)
 
-            Text(viewModel.formTitle)
+            Text(self.viewModel.formTitle)
                 .font(.headline)
 
             Spacer()
@@ -97,9 +102,9 @@ struct MCPServerEditorView: View {
                         .font(.subheadline)
                         .fontWeight(.medium)
 
-                    TextField("my-server", text: $viewModel.formData.name)
+                    TextField("my-server", text: self.$viewModel.formData.name)
                         .textFieldStyle(.roundedBorder)
-                        .focused($focusedField, equals: .name)
+                        .focused(self.$focusedField, equals: .name)
                         .accessibilityLabel("Server name")
 
                     if let error = viewModel.error(for: "name") {
@@ -115,7 +120,7 @@ struct MCPServerEditorView: View {
                         .font(.subheadline)
                         .fontWeight(.medium)
 
-                    Picker("Type", selection: $viewModel.formData.serverType) {
+                    Picker("Type", selection: self.$viewModel.formData.serverType) {
                         ForEach(MCPServerType.allCases) { type in
                             Label(type.displayName, systemImage: type.icon)
                                 .tag(type)
@@ -137,14 +142,14 @@ struct MCPServerEditorView: View {
                     .font(.subheadline)
                     .fontWeight(.medium)
 
-                Picker("Scope", selection: $viewModel.formData.scope) {
+                Picker("Scope", selection: self.$viewModel.formData.scope) {
                     ForEach(MCPServerScope.allCases) { scope in
                         Label(scope.displayName, systemImage: scope.icon)
                             .tag(scope)
                     }
                 }
                 .pickerStyle(.radioGroup)
-                .disabled(viewModel.projectPath == nil && viewModel.formData.scope == .project)
+                .disabled(self.viewModel.projectPath == nil && self.viewModel.formData.scope == .project)
             }
             .padding(.vertical, 4)
         } label: {
@@ -161,10 +166,10 @@ struct MCPServerEditorView: View {
                         .font(.subheadline)
                         .fontWeight(.medium)
 
-                    TextField("npx", text: $viewModel.formData.command)
+                    TextField("npx", text: self.$viewModel.formData.command)
                         .textFieldStyle(.roundedBorder)
                         .font(.system(.body, design: .monospaced))
-                        .focused($focusedField, equals: .command)
+                        .focused(self.$focusedField, equals: .command)
                         .accessibilityLabel("Command")
 
                     if let error = viewModel.error(for: "command") {
@@ -184,7 +189,7 @@ struct MCPServerEditorView: View {
                     }
 
                     TagInputView(
-                        tags: $viewModel.formData.args,
+                        tags: self.$viewModel.formData.args,
                         placeholder: "Add argument..."
                     )
                 }
@@ -197,7 +202,7 @@ struct MCPServerEditorView: View {
                             .fontWeight(.medium)
                         Spacer()
                         Button {
-                            viewModel.formData.addEnvVar()
+                            self.viewModel.formData.addEnvVar()
                         } label: {
                             Image(systemName: "plus.circle")
                         }
@@ -205,19 +210,19 @@ struct MCPServerEditorView: View {
                         .accessibilityLabel("Add environment variable")
                     }
 
-                    if viewModel.formData.envVars.isEmpty {
+                    if self.viewModel.formData.envVars.isEmpty {
                         Text("No environment variables")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     } else {
-                        ForEach(Array(viewModel.formData.envVars.enumerated()), id: \.element.id) { index, _ in
+                        ForEach(Array(self.viewModel.formData.envVars.enumerated()), id: \.element.id) { index, _ in
                             KeyValueRow(
-                                key: $viewModel.formData.envVars[index].key,
-                                value: $viewModel.formData.envVars[index].value,
+                                key: self.$viewModel.formData.envVars[index].key,
+                                value: self.$viewModel.formData.envVars[index].value,
                                 keyPlaceholder: "KEY",
                                 valuePlaceholder: "value",
                                 onDelete: {
-                                    viewModel.formData.removeEnvVar(at: index)
+                                    self.viewModel.formData.removeEnvVar(at: index)
                                 }
                             )
                         }
@@ -239,10 +244,10 @@ struct MCPServerEditorView: View {
                         .font(.subheadline)
                         .fontWeight(.medium)
 
-                    TextField("https://mcp.example.com/api", text: $viewModel.formData.url)
+                    TextField("https://mcp.example.com/api", text: self.$viewModel.formData.url)
                         .textFieldStyle(.roundedBorder)
                         .font(.system(.body, design: .monospaced))
-                        .focused($focusedField, equals: .url)
+                        .focused(self.$focusedField, equals: .url)
                         .accessibilityLabel("Server URL")
 
                     if let error = viewModel.error(for: "url") {
@@ -260,7 +265,7 @@ struct MCPServerEditorView: View {
                             .fontWeight(.medium)
                         Spacer()
                         Button {
-                            viewModel.formData.addHeader()
+                            self.viewModel.formData.addHeader()
                         } label: {
                             Image(systemName: "plus.circle")
                         }
@@ -268,19 +273,19 @@ struct MCPServerEditorView: View {
                         .accessibilityLabel("Add header")
                     }
 
-                    if viewModel.formData.headers.isEmpty {
+                    if self.viewModel.formData.headers.isEmpty {
                         Text("No headers")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     } else {
-                        ForEach(Array(viewModel.formData.headers.enumerated()), id: \.element.id) { index, _ in
+                        ForEach(Array(self.viewModel.formData.headers.enumerated()), id: \.element.id) { index, _ in
                             KeyValueRow(
-                                key: $viewModel.formData.headers[index].key,
-                                value: $viewModel.formData.headers[index].value,
+                                key: self.$viewModel.formData.headers[index].key,
+                                value: self.$viewModel.formData.headers[index].value,
                                 keyPlaceholder: "Header-Name",
                                 valuePlaceholder: "value",
                                 onDelete: {
-                                    viewModel.formData.removeHeader(at: index)
+                                    self.viewModel.formData.removeHeader(at: index)
                                 }
                             )
                         }
@@ -296,14 +301,14 @@ struct MCPServerEditorView: View {
     private var importSection: some View {
         DisclosureGroup {
             VStack(alignment: .leading, spacing: 12) {
-                Picker("Import Type", selection: $importType) {
+                Picker("Import Type", selection: self.$importType) {
                     ForEach(ImportType.allCases) { type in
                         Text(type.rawValue).tag(type)
                     }
                 }
                 .pickerStyle(.segmented)
 
-                TextEditor(text: $importText)
+                TextEditor(text: self.$importText)
                     .font(.system(.caption, design: .monospaced))
                     .frame(height: 80)
                     .overlay(
@@ -314,16 +319,16 @@ struct MCPServerEditorView: View {
                 HStack {
                     Spacer()
                     Button("Import") {
-                        let success = if importType == .json {
-                            viewModel.importFromJSON(importText)
+                        let success = if self.importType == .json {
+                            self.viewModel.importFromJSON(self.importText)
                         } else {
-                            viewModel.importFromCLICommand(importText)
+                            self.viewModel.importFromCLICommand(self.importText)
                         }
                         if success {
-                            importText = ""
+                            self.importText = ""
                         }
                     }
-                    .disabled(importText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .disabled(self.importText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
             .padding(.top, 8)
@@ -336,21 +341,21 @@ struct MCPServerEditorView: View {
     private var footer: some View {
         HStack {
             Button("Cancel") {
-                dismiss()
+                self.dismiss()
             }
             .keyboardShortcut(.cancelAction)
 
             Spacer()
 
-            Button(viewModel.isEditing ? "Save" : "Add Server") {
+            Button(self.viewModel.isEditing ? "Save" : "Add Server") {
                 Task {
-                    if await viewModel.save() {
-                        dismiss()
+                    if await self.viewModel.save() {
+                        self.dismiss()
                     }
                 }
             }
             .buttonStyle(.borderedProminent)
-            .disabled(!viewModel.canSave)
+            .disabled(!self.viewModel.canSave)
             .keyboardShortcut(.defaultAction)
         }
         .padding()
@@ -361,47 +366,54 @@ struct MCPServerEditorView: View {
 
 /// A view for entering tags/arguments with add/remove functionality.
 struct TagInputView: View {
-    @Binding var tags: [String]
-    var placeholder: String = "Add tag..."
+    // MARK: Internal
 
-    @State private var newTagText = ""
+    @Binding var tags: [String]
+
+    var placeholder: String = "Add tag..."
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             // Tag display
             FlowLayout(spacing: 4) {
-                ForEach(Array(tags.enumerated()), id: \.offset) { index, tag in
+                ForEach(Array(self.tags.enumerated()), id: \.offset) { index, tag in
                     TagChip(text: tag) {
-                        tags.remove(at: index)
+                        self.tags.remove(at: index)
                     }
                 }
             }
 
             // Input field
             HStack {
-                TextField(placeholder, text: $newTagText)
+                TextField(self.placeholder, text: self.$newTagText)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
                     .onSubmit {
-                        addTag()
+                        self.addTag()
                     }
 
                 Button {
-                    addTag()
+                    self.addTag()
                 } label: {
                     Image(systemName: "plus.circle.fill")
                 }
                 .buttonStyle(.plain)
-                .disabled(newTagText.trimmingCharacters(in: .whitespaces).isEmpty)
+                .disabled(self.newTagText.trimmingCharacters(in: .whitespaces).isEmpty)
             }
         }
     }
 
+    // MARK: Private
+
+    @State private var newTagText = ""
+
     private func addTag() {
-        let trimmed = newTagText.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty else { return }
-        tags.append(trimmed)
-        newTagText = ""
+        let trimmed = self.newTagText.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else {
+            return
+        }
+        self.tags.append(trimmed)
+        self.newTagText = ""
     }
 }
 
@@ -414,17 +426,17 @@ struct TagChip: View {
 
     var body: some View {
         HStack(spacing: 4) {
-            Text(text)
+            Text(self.text)
                 .font(.system(.caption, design: .monospaced))
 
             Button {
-                onRemove()
+                self.onRemove()
             } label: {
                 Image(systemName: "xmark.circle.fill")
                     .font(.caption2)
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Remove \(text)")
+            .accessibilityLabel("Remove \(self.text)")
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
@@ -438,13 +450,14 @@ struct TagChip: View {
 struct KeyValueRow: View {
     @Binding var key: String
     @Binding var value: String
+
     var keyPlaceholder: String = "Key"
     var valuePlaceholder: String = "Value"
     var onDelete: () -> Void
 
     var body: some View {
         HStack(spacing: 8) {
-            TextField(keyPlaceholder, text: $key)
+            TextField(self.keyPlaceholder, text: self.$key)
                 .textFieldStyle(.roundedBorder)
                 .font(.system(.caption, design: .monospaced))
                 .frame(width: 150)
@@ -452,12 +465,12 @@ struct KeyValueRow: View {
             Text("=")
                 .foregroundStyle(.secondary)
 
-            TextField(valuePlaceholder, text: $value)
+            TextField(self.valuePlaceholder, text: self.$value)
                 .textFieldStyle(.roundedBorder)
                 .font(.system(.caption, design: .monospaced))
 
             Button {
-                onDelete()
+                self.onDelete()
             } label: {
                 Image(systemName: "minus.circle.fill")
                     .foregroundStyle(.red)

--- a/Fig/Sources/Views/Onboarding/OnboardingDiscoveryView.swift
+++ b/Fig/Sources/Views/Onboarding/OnboardingDiscoveryView.swift
@@ -82,27 +82,6 @@ struct OnboardingDiscoveryView: View {
         }
     }
 
-    private func errorContent(_ error: String) -> some View {
-        VStack(spacing: 16) {
-            Text("Discovery Issue")
-                .font(.largeTitle)
-                .fontWeight(.bold)
-
-            Text(error)
-                .font(.body)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 400)
-
-            Button("Retry") {
-                Task {
-                    await self.viewModel.runDiscovery()
-                }
-            }
-            .buttonStyle(.bordered)
-        }
-    }
-
     private var emptyContent: some View {
         VStack(spacing: 16) {
             Text("No Projects Found")
@@ -160,6 +139,27 @@ struct OnboardingDiscoveryView: View {
         .frame(maxHeight: 250)
         .background(.quaternary.opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func errorContent(_ error: String) -> some View {
+        VStack(spacing: 16) {
+            Text("Discovery Issue")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+
+            Text(error)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 400)
+
+            Button("Retry") {
+                Task {
+                    await self.viewModel.runDiscovery()
+                }
+            }
+            .buttonStyle(.bordered)
+        }
     }
 
     private func projectRow(_ project: DiscoveredProject) -> some View {

--- a/Fig/Sources/Views/Onboarding/OnboardingTourView.swift
+++ b/Fig/Sources/Views/Onboarding/OnboardingTourView.swift
@@ -70,10 +70,6 @@ struct OnboardingTourView: View {
         .animation(.easeInOut(duration: 0.25), value: self.viewModel.currentTourPage)
     }
 
-    private var isLastTourPage: Bool {
-        self.viewModel.currentTourPage == OnboardingViewModel.tourPageCount - 1
-    }
-
     // MARK: Private
 
     private struct TourPageData {
@@ -103,8 +99,27 @@ struct OnboardingTourView: View {
             icon: "globe",
             title: "Global Settings",
             description: "Manage global Claude Code settings that apply across all your projects. Set default permissions, environment variables, and hooks in one place."
-        )
+        ),
     ]
+
+    private var isLastTourPage: Bool {
+        self.viewModel.currentTourPage == OnboardingViewModel.tourPageCount - 1
+    }
+
+    private var pageIndicator: some View {
+        HStack(spacing: 8) {
+            ForEach(0 ..< OnboardingViewModel.tourPageCount, id: \.self) { index in
+                Circle()
+                    .fill(
+                        index == self.viewModel.currentTourPage
+                            ? Color.accentColor
+                            : Color.secondary.opacity(0.3)
+                    )
+                    .frame(width: 8, height: 8)
+            }
+        }
+    }
+
     // swiftlint:enable line_length
 
     @ViewBuilder
@@ -125,20 +140,6 @@ struct OnboardingTourView: View {
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 500)
-        }
-    }
-
-    private var pageIndicator: some View {
-        HStack(spacing: 8) {
-            ForEach(0 ..< OnboardingViewModel.tourPageCount, id: \.self) { index in
-                Circle()
-                    .fill(
-                        index == self.viewModel.currentTourPage
-                            ? Color.accentColor
-                            : Color.secondary.opacity(0.3)
-                    )
-                    .frame(width: 8, height: 8)
-            }
         }
     }
 }

--- a/Fig/Sources/Views/PermissionEditorViews.swift
+++ b/Fig/Sources/Views/PermissionEditorViews.swift
@@ -16,8 +16,8 @@ struct PermissionRuleEditorView: View {
             VStack(alignment: .leading, spacing: 16) {
                 // Target selector and quick-add
                 HStack {
-                    if !viewModel.isGlobalMode {
-                        EditingTargetPicker(selection: $viewModel.editingTarget)
+                    if !self.viewModel.isGlobalMode {
+                        EditingTargetPicker(selection: self.$viewModel.editingTarget)
                     }
 
                     Spacer()
@@ -25,7 +25,7 @@ struct PermissionRuleEditorView: View {
                     Menu {
                         ForEach(PermissionPreset.allPresets) { preset in
                             Button {
-                                viewModel.applyPreset(preset)
+                                self.viewModel.applyPreset(preset)
                             } label: {
                                 VStack(alignment: .leading) {
                                     Text(preset.name)
@@ -51,33 +51,33 @@ struct PermissionRuleEditorView: View {
                             Spacer()
 
                             Button {
-                                showingAddAllowRule = true
+                                self.showingAddAllowRule = true
                             } label: {
                                 Label("Add Rule", systemImage: "plus")
                             }
                             .buttonStyle(.borderless)
                         }
 
-                        if viewModel.allowRules.isEmpty {
+                        if self.viewModel.allowRules.isEmpty {
                             Text("No allow rules configured.")
                                 .foregroundStyle(.secondary)
                                 .padding(.vertical, 8)
                         } else {
-                            ForEach(viewModel.allowRules) { rule in
+                            ForEach(self.viewModel.allowRules) { rule in
                                 EditablePermissionRuleRow(
                                     rule: rule,
                                     onUpdate: { newRule, newType in
-                                        viewModel.updatePermissionRule(rule, newRule: newRule, newType: newType)
+                                        self.viewModel.updatePermissionRule(rule, newRule: newRule, newType: newType)
                                     },
                                     onDelete: {
-                                        viewModel.removePermissionRule(rule)
+                                        self.viewModel.removePermissionRule(rule)
                                     },
-                                    validateRule: viewModel.validatePermissionRule,
+                                    validateRule: self.viewModel.validatePermissionRule,
                                     isDuplicate: { ruleStr, type in
-                                        viewModel.isRuleDuplicate(ruleStr, type: type, excluding: rule)
+                                        self.viewModel.isRuleDuplicate(ruleStr, type: type, excluding: rule)
                                     },
-                                    onPromoteToGlobal: onPromoteToGlobal != nil ? {
-                                        onPromoteToGlobal?(rule.rule, .allow)
+                                    onPromoteToGlobal: self.onPromoteToGlobal != nil ? {
+                                        self.onPromoteToGlobal?(rule.rule, .allow)
                                     } : nil
                                 )
                             }
@@ -97,33 +97,33 @@ struct PermissionRuleEditorView: View {
                             Spacer()
 
                             Button {
-                                showingAddDenyRule = true
+                                self.showingAddDenyRule = true
                             } label: {
                                 Label("Add Rule", systemImage: "plus")
                             }
                             .buttonStyle(.borderless)
                         }
 
-                        if viewModel.denyRules.isEmpty {
+                        if self.viewModel.denyRules.isEmpty {
                             Text("No deny rules configured.")
                                 .foregroundStyle(.secondary)
                                 .padding(.vertical, 8)
                         } else {
-                            ForEach(viewModel.denyRules) { rule in
+                            ForEach(self.viewModel.denyRules) { rule in
                                 EditablePermissionRuleRow(
                                     rule: rule,
                                     onUpdate: { newRule, newType in
-                                        viewModel.updatePermissionRule(rule, newRule: newRule, newType: newType)
+                                        self.viewModel.updatePermissionRule(rule, newRule: newRule, newType: newType)
                                     },
                                     onDelete: {
-                                        viewModel.removePermissionRule(rule)
+                                        self.viewModel.removePermissionRule(rule)
                                     },
-                                    validateRule: viewModel.validatePermissionRule,
+                                    validateRule: self.viewModel.validatePermissionRule,
                                     isDuplicate: { ruleStr, type in
-                                        viewModel.isRuleDuplicate(ruleStr, type: type, excluding: rule)
+                                        self.viewModel.isRuleDuplicate(ruleStr, type: type, excluding: rule)
                                     },
-                                    onPromoteToGlobal: onPromoteToGlobal != nil ? {
-                                        onPromoteToGlobal?(rule.rule, .deny)
+                                    onPromoteToGlobal: self.onPromoteToGlobal != nil ? {
+                                        self.onPromoteToGlobal?(rule.rule, .deny)
                                     } : nil
                                 )
                             }
@@ -136,22 +136,22 @@ struct PermissionRuleEditorView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .sheet(isPresented: $showingAddAllowRule) {
+        .sheet(isPresented: self.$showingAddAllowRule) {
             AddPermissionRuleSheet(type: .allow) { rule in
-                viewModel.addPermissionRule(rule, type: .allow)
+                self.viewModel.addPermissionRule(rule, type: .allow)
             } validateRule: { rule in
-                viewModel.validatePermissionRule(rule)
+                self.viewModel.validatePermissionRule(rule)
             } isDuplicate: { rule in
-                viewModel.isRuleDuplicate(rule, type: .allow)
+                self.viewModel.isRuleDuplicate(rule, type: .allow)
             }
         }
-        .sheet(isPresented: $showingAddDenyRule) {
+        .sheet(isPresented: self.$showingAddDenyRule) {
             AddPermissionRuleSheet(type: .deny) { rule in
-                viewModel.addPermissionRule(rule, type: .deny)
+                self.viewModel.addPermissionRule(rule, type: .deny)
             } validateRule: { rule in
-                viewModel.validatePermissionRule(rule)
+                self.viewModel.validatePermissionRule(rule)
             } isDuplicate: { rule in
-                viewModel.isRuleDuplicate(rule, type: .deny)
+                self.viewModel.isRuleDuplicate(rule, type: .deny)
             }
         }
     }
@@ -177,29 +177,29 @@ struct EditablePermissionRuleRow: View {
 
     var body: some View {
         HStack {
-            Image(systemName: rule.type.icon)
-                .foregroundStyle(rule.type == .allow ? .green : .red)
+            Image(systemName: self.rule.type.icon)
+                .foregroundStyle(self.rule.type == .allow ? .green : .red)
                 .frame(width: 20)
 
-            if isEditing {
-                TextField("Rule pattern", text: $editedRule)
+            if self.isEditing {
+                TextField("Rule pattern", text: self.$editedRule)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
                     .onSubmit {
-                        saveEdit()
+                        self.saveEdit()
                     }
 
                 Button("Save") {
-                    saveEdit()
+                    self.saveEdit()
                 }
-                .disabled(!canSave)
+                .disabled(!self.canSave)
 
                 Button("Cancel") {
-                    isEditing = false
-                    editedRule = rule.rule
+                    self.isEditing = false
+                    self.editedRule = self.rule.rule
                 }
             } else {
-                Text(rule.rule)
+                Text(self.rule.rule)
                     .font(.system(.body, design: .monospaced))
                     .lineLimit(1)
                     .truncationMode(.middle)
@@ -207,8 +207,8 @@ struct EditablePermissionRuleRow: View {
                 Spacer()
 
                 Button {
-                    isEditing = true
-                    editedRule = rule.rule
+                    self.isEditing = true
+                    self.editedRule = self.rule.rule
                 } label: {
                     Image(systemName: "pencil")
                         .font(.caption)
@@ -216,7 +216,7 @@ struct EditablePermissionRuleRow: View {
                 .buttonStyle(.plain)
 
                 Button {
-                    showingDeleteConfirmation = true
+                    self.showingDeleteConfirmation = true
                 } label: {
                     Image(systemName: "trash")
                         .font(.caption)
@@ -233,20 +233,20 @@ struct EditablePermissionRuleRow: View {
         )
         .confirmationDialog(
             "Delete Rule",
-            isPresented: $showingDeleteConfirmation,
+            isPresented: self.$showingDeleteConfirmation,
             titleVisibility: .visible
         ) {
             Button("Delete", role: .destructive) {
-                onDelete()
+                self.onDelete()
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("Are you sure you want to delete this rule?\n\(rule.rule)")
+            Text("Are you sure you want to delete this rule?\n\(self.rule.rule)")
         }
         .contextMenu {
             Button {
                 NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(rule.rule, forType: .string)
+                NSPasteboard.general.setString(self.rule.rule, forType: .string)
             } label: {
                 Label("Copy Rule", systemImage: "doc.on.doc")
             }
@@ -264,7 +264,7 @@ struct EditablePermissionRuleRow: View {
             Divider()
 
             Button(role: .destructive) {
-                showingDeleteConfirmation = true
+                self.showingDeleteConfirmation = true
             } label: {
                 Label("Delete", systemImage: "trash")
             }
@@ -278,14 +278,16 @@ struct EditablePermissionRuleRow: View {
     @State private var showingDeleteConfirmation = false
 
     private var canSave: Bool {
-        let validation = validateRule(editedRule)
-        return validation.isValid && !isDuplicate(editedRule, rule.type)
+        let validation = self.validateRule(self.editedRule)
+        return validation.isValid && !self.isDuplicate(self.editedRule, self.rule.type)
     }
 
     private func saveEdit() {
-        guard canSave else { return }
-        onUpdate(editedRule, rule.type)
-        isEditing = false
+        guard self.canSave else {
+            return
+        }
+        self.onUpdate(self.editedRule, self.rule.type)
+        self.isEditing = false
     }
 }
 
@@ -318,10 +320,10 @@ struct AddPermissionRuleSheet: View {
         VStack(alignment: .leading, spacing: 16) {
             // Header
             HStack {
-                Image(systemName: type == .allow ? "checkmark.circle.fill" : "xmark.circle.fill")
-                    .foregroundStyle(type == .allow ? .green : .red)
+                Image(systemName: self.type == .allow ? "checkmark.circle.fill" : "xmark.circle.fill")
+                    .foregroundStyle(self.type == .allow ? .green : .red)
                     .font(.title2)
-                Text("Add \(type == .allow ? "Allow" : "Deny") Rule")
+                Text("Add \(self.type == .allow ? "Allow" : "Deny") Rule")
                     .font(.title2)
                     .fontWeight(.semibold)
             }
@@ -332,7 +334,7 @@ struct AddPermissionRuleSheet: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Tool Type")
                     .font(.headline)
-                Picker("Tool Type", selection: $selectedTool) {
+                Picker("Tool Type", selection: self.$selectedTool) {
                     ForEach(ToolType.allCases) { tool in
                         Text(tool.rawValue).tag(tool)
                     }
@@ -341,11 +343,11 @@ struct AddPermissionRuleSheet: View {
             }
 
             // Custom tool name (if custom selected)
-            if selectedTool == .custom {
+            if self.selectedTool == .custom {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Custom Tool Name")
                         .font(.headline)
-                    TextField("ToolName", text: $customToolName)
+                    TextField("ToolName", text: self.$customToolName)
                         .textFieldStyle(.roundedBorder)
                 }
             }
@@ -354,7 +356,7 @@ struct AddPermissionRuleSheet: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Pattern (optional)")
                     .font(.headline)
-                TextField(selectedTool.placeholder, text: $pattern)
+                TextField(self.selectedTool.placeholder, text: self.$pattern)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
                 Text("Use * for wildcard, ** for recursive match")
@@ -367,9 +369,9 @@ struct AddPermissionRuleSheet: View {
                 Text("Preview")
                     .font(.headline)
                 HStack {
-                    Image(systemName: type.icon)
-                        .foregroundStyle(type == .allow ? .green : .red)
-                    Text(generatedRule)
+                    Image(systemName: self.type.icon)
+                        .foregroundStyle(self.type == .allow ? .green : .red)
+                    Text(self.generatedRule)
                         .font(.system(.body, design: .monospaced))
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
@@ -393,18 +395,18 @@ struct AddPermissionRuleSheet: View {
             // Buttons
             HStack {
                 Button("Cancel") {
-                    dismiss()
+                    self.dismiss()
                 }
                 .keyboardShortcut(.cancelAction)
 
                 Spacer()
 
                 Button("Add Rule") {
-                    onAdd(generatedRule)
-                    dismiss()
+                    self.onAdd(self.generatedRule)
+                    self.dismiss()
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(!isValid)
+                .disabled(!self.isValid)
             }
         }
         .padding()
@@ -421,29 +423,29 @@ struct AddPermissionRuleSheet: View {
     @State private var pattern = ""
 
     private var toolName: String {
-        selectedTool == .custom ? customToolName : selectedTool.rawValue
+        self.selectedTool == .custom ? self.customToolName : self.selectedTool.rawValue
     }
 
     private var generatedRule: String {
-        if pattern.isEmpty {
-            return toolName
+        if self.pattern.isEmpty {
+            return self.toolName
         }
-        return "\(toolName)(\(pattern))"
+        return "\(self.toolName)(\(self.pattern))"
     }
 
     private var validationError: String? {
-        if selectedTool == .custom, customToolName.isEmpty {
+        if self.selectedTool == .custom, self.customToolName.isEmpty {
             return "Enter a custom tool name"
         }
-        if isDuplicate(generatedRule) {
+        if self.isDuplicate(self.generatedRule) {
             return "This rule already exists"
         }
-        let validation = validateRule(generatedRule)
+        let validation = self.validateRule(self.generatedRule)
         return validation.error
     }
 
     private var isValid: Bool {
-        validationError == nil && !toolName.isEmpty
+        self.validationError == nil && !self.toolName.isEmpty
     }
 }
 
@@ -461,6 +463,7 @@ struct RulePromotionInfo {
 struct PromoteToGlobalModifier: ViewModifier {
     @Binding var isPresented: Bool
     @Binding var ruleToPromote: RulePromotionInfo?
+
     let projectURL: URL?
     var onComplete: (() async -> Void)?
 
@@ -468,8 +471,8 @@ struct PromoteToGlobalModifier: ViewModifier {
         content
             .alert(
                 "Promote to Global",
-                isPresented: $isPresented,
-                presenting: ruleToPromote
+                isPresented: self.$isPresented,
+                presenting: self.ruleToPromote
             ) { ruleInfo in
                 Button("Cancel", role: .cancel) {}
                 Button("Promote") {
@@ -479,7 +482,7 @@ struct PromoteToGlobalModifier: ViewModifier {
                                 rule: ruleInfo.rule,
                                 type: ruleInfo.type,
                                 to: .global,
-                                projectPath: projectURL
+                                projectPath: self.projectURL
                             )
                             if added {
                                 NotificationManager.shared.showSuccess(
@@ -492,7 +495,7 @@ struct PromoteToGlobalModifier: ViewModifier {
                                     message: "This rule already exists in global settings"
                                 )
                             }
-                            await onComplete?()
+                            await self.onComplete?()
                         } catch {
                             NotificationManager.shared.showError(error)
                         }
@@ -526,7 +529,7 @@ extension View {
     viewModel.permissionRules = [
         EditablePermissionRule(rule: "Bash(npm run *)", type: .allow),
         EditablePermissionRule(rule: "Read(src/**)", type: .allow),
-        EditablePermissionRule(rule: "Read(.env)", type: .deny)
+        EditablePermissionRule(rule: "Read(.env)", type: .deny),
     ]
 
     return PermissionRuleEditorView(viewModel: viewModel)

--- a/Fig/Sources/Views/SettingsEditorViews.swift
+++ b/Fig/Sources/Views/SettingsEditorViews.swift
@@ -5,11 +5,12 @@ import SwiftUI
 /// Picker for selecting the editing target file.
 struct EditingTargetPicker: View {
     @Binding var selection: EditingTarget
+
     var targets: [EditingTarget] = EditingTarget.projectTargets
 
     var body: some View {
-        Picker("Save to:", selection: $selection) {
-            ForEach(targets) { target in
+        Picker("Save to:", selection: self.$selection) {
+            ForEach(self.targets) { target in
                 HStack {
                     Image(systemName: target.source.icon)
                     Text(target.label)
@@ -19,7 +20,7 @@ struct EditingTargetPicker: View {
         }
         .pickerStyle(.segmented)
         .frame(maxWidth: 350)
-        .help(selection.description)
+        .help(self.selection.description)
     }
 }
 
@@ -27,8 +28,6 @@ struct EditingTargetPicker: View {
 
 /// Sheet for resolving external file change conflicts.
 struct ConflictResolutionSheet: View {
-    // MARK: Internal
-
     let fileName: String
     let onResolve: (ConflictResolution) -> Void
 
@@ -44,7 +43,7 @@ struct ConflictResolutionSheet: View {
                     .fontWeight(.semibold)
             }
 
-            Text("The file \(fileName) was modified externally while you have unsaved changes.")
+            Text("The file \(self.fileName) was modified externally while you have unsaved changes.")
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
 
@@ -52,7 +51,7 @@ struct ConflictResolutionSheet: View {
 
             VStack(spacing: 12) {
                 Button {
-                    onResolve(.keepLocal)
+                    self.onResolve(.keepLocal)
                 } label: {
                     HStack {
                         Image(systemName: "pencil.circle.fill")
@@ -72,7 +71,7 @@ struct ConflictResolutionSheet: View {
                 .buttonStyle(.plain)
 
                 Button {
-                    onResolve(.useExternal)
+                    self.onResolve(.useExternal)
                 } label: {
                     HStack {
                         Image(systemName: "arrow.down.circle.fill")
@@ -106,7 +105,7 @@ struct DirtyStateIndicator: View {
     let isDirty: Bool
 
     var body: some View {
-        if isDirty {
+        if self.isDirty {
             Circle()
                 .fill(.orange)
                 .frame(width: 8, height: 8)
@@ -125,15 +124,15 @@ struct SaveButton: View {
     let action: () -> Void
 
     var body: some View {
-        Button(action: action) {
-            if isSaving {
+        Button(action: self.action) {
+            if self.isSaving {
                 ProgressView()
                     .controlSize(.small)
             } else {
                 Label("Save", systemImage: "square.and.arrow.down")
             }
         }
-        .disabled(!isDirty || isSaving)
+        .disabled(!self.isDirty || self.isSaving)
         .keyboardShortcut("s", modifiers: .command)
     }
 }
@@ -148,12 +147,12 @@ struct EditSettingsButton: View {
 
     var body: some View {
         Button {
-            showingEditor = true
+            self.showingEditor = true
         } label: {
             Label("Edit Settings", systemImage: "pencil")
         }
-        .sheet(isPresented: $showingEditor) {
-            ProjectSettingsEditorView(projectPath: projectPath)
+        .sheet(isPresented: self.$showingEditor) {
+            ProjectSettingsEditorView(projectPath: self.projectPath)
         }
     }
 

--- a/Fig/Sources/Views/SidebarView.swift
+++ b/Fig/Sources/Views/SidebarView.swift
@@ -186,7 +186,9 @@ struct SidebarView: View {
                         self.selection = nil
                     }
                     let projectsToDelete = self.viewModel.projects.filter { project in
-                        guard let path = project.path else { return false }
+                        guard let path = project.path else {
+                            return false
+                        }
                         return self.selectedProjectPaths.contains(path)
                     }
                     await self.viewModel.deleteProjects(projectsToDelete)
@@ -221,33 +223,6 @@ struct SidebarView: View {
     private var allProjectsSelected: Bool {
         let visible = self.visibleProjectPaths
         return !visible.isEmpty && visible.isSubset(of: self.selectedProjectPaths)
-    }
-
-    private func toggleSelectMode() {
-        withAnimation {
-            self.isSelectMode.toggle()
-            if !self.isSelectMode {
-                self.selectedProjectPaths.removeAll()
-            }
-        }
-    }
-
-    private func toggleProjectSelection(_ project: ProjectEntry) {
-        guard let path = project.path else { return }
-        if self.selectedProjectPaths.contains(path) {
-            self.selectedProjectPaths.remove(path)
-        } else {
-            self.selectedProjectPaths.insert(path)
-        }
-    }
-
-    private func isProjectSelected(_ project: ProjectEntry) -> Bool {
-        guard let path = project.path else { return false }
-        return self.selectedProjectPaths.contains(path)
-    }
-
-    private func selectAllProjects() {
-        self.selectedProjectPaths = self.visibleProjectPaths
     }
 
     @ViewBuilder
@@ -317,6 +292,37 @@ struct SidebarView: View {
                 }
         }
     }
+
+    private func toggleSelectMode() {
+        withAnimation {
+            self.isSelectMode.toggle()
+            if !self.isSelectMode {
+                self.selectedProjectPaths.removeAll()
+            }
+        }
+    }
+
+    private func toggleProjectSelection(_ project: ProjectEntry) {
+        guard let path = project.path else {
+            return
+        }
+        if self.selectedProjectPaths.contains(path) {
+            self.selectedProjectPaths.remove(path)
+        } else {
+            self.selectedProjectPaths.insert(path)
+        }
+    }
+
+    private func isProjectSelected(_ project: ProjectEntry) -> Bool {
+        guard let path = project.path else {
+            return false
+        }
+        return self.selectedProjectPaths.contains(path)
+    }
+
+    private func selectAllProjects() {
+        self.selectedProjectPaths = self.visibleProjectPaths
+    }
 }
 
 // MARK: - ProjectRowView
@@ -385,22 +391,22 @@ struct ProjectRowView: View {
         }
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityDescription)
+        .accessibilityLabel(self.accessibilityDescription)
     }
 
     // MARK: Private
 
     private var accessibilityDescription: String {
         var parts: [String] = []
-        parts.append(project.name ?? "Unknown project")
-        if !exists {
+        parts.append(self.project.name ?? "Unknown project")
+        if !self.exists {
             parts.append("directory not found")
         }
-        if isFavorite {
+        if self.isFavorite {
             parts.append("favorite")
         }
-        if mcpCount > 0 {
-            parts.append("\(mcpCount) MCP server\(mcpCount == 1 ? "" : "s")")
+        if self.mcpCount > 0 {
+            parts.append("\(self.mcpCount) MCP server\(self.mcpCount == 1 ? "" : "s")")
         }
         return parts.joined(separator: ", ")
     }

--- a/Fig/Tests/ConfigHealthCheckTests.swift
+++ b/Fig/Tests/ConfigHealthCheckTests.swift
@@ -30,7 +30,7 @@ enum HealthCheckTestHelpers {
     }
 }
 
-// MARK: - DenyListSecurityCheck Tests
+// MARK: - DenyListSecurityCheckTests
 
 @Suite("DenyListSecurityCheck Tests")
 struct DenyListSecurityCheckTests {
@@ -39,7 +39,7 @@ struct DenyListSecurityCheckTests {
     @Test("Flags missing .env deny rule")
     func flagsMissingEnvDeny() {
         let context = HealthCheckTestHelpers.makeContext()
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         let envFinding = findings.first { $0.title.contains(".env") }
         #expect(envFinding != nil)
@@ -50,7 +50,7 @@ struct DenyListSecurityCheckTests {
     @Test("Flags missing secrets/ deny rule")
     func flagsMissingSecretsDeny() {
         let context = HealthCheckTestHelpers.makeContext()
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         let secretsFinding = findings.first { $0.title.contains("secrets/") }
         #expect(secretsFinding != nil)
@@ -62,7 +62,7 @@ struct DenyListSecurityCheckTests {
     func noFindingWhenEnvDenied() {
         let settings = ClaudeSettings(permissions: Permissions(deny: ["Read(.env)"]))
         let context = HealthCheckTestHelpers.makeContext(projectSettings: settings)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         let envFinding = findings.first { $0.title.contains(".env") }
         #expect(envFinding == nil)
@@ -72,7 +72,7 @@ struct DenyListSecurityCheckTests {
     func noFindingWhenSecretsDenied() {
         let settings = ClaudeSettings(permissions: Permissions(deny: ["Read(secrets/**)"]))
         let context = HealthCheckTestHelpers.makeContext(projectSettings: settings)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         let secretsFinding = findings.first { $0.title.contains("secrets/") }
         #expect(secretsFinding == nil)
@@ -86,13 +86,13 @@ struct DenyListSecurityCheckTests {
             globalSettings: global,
             projectLocalSettings: local
         )
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
 }
 
-// MARK: - BroadAllowRulesCheck Tests
+// MARK: - BroadAllowRulesCheckTests
 
 @Suite("BroadAllowRulesCheck Tests")
 struct BroadAllowRulesCheckTests {
@@ -102,7 +102,7 @@ struct BroadAllowRulesCheckTests {
     func flagsBroadBash() {
         let settings = ClaudeSettings(permissions: Permissions(allow: ["Bash(*)"]))
         let context = HealthCheckTestHelpers.makeContext(projectSettings: settings)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.count == 1)
         #expect(findings.first?.severity == .warning)
@@ -113,7 +113,7 @@ struct BroadAllowRulesCheckTests {
     func doesNotFlagSpecific() {
         let settings = ClaudeSettings(permissions: Permissions(allow: ["Bash(npm run *)"]))
         let context = HealthCheckTestHelpers.makeContext(projectSettings: settings)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
@@ -122,7 +122,7 @@ struct BroadAllowRulesCheckTests {
     func flagsMultipleBroad() {
         let settings = ClaudeSettings(permissions: Permissions(allow: ["Bash(*)", "Read(*)"]))
         let context = HealthCheckTestHelpers.makeContext(projectSettings: settings)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.count == 2)
     }
@@ -131,13 +131,13 @@ struct BroadAllowRulesCheckTests {
     func noAutoFix() {
         let settings = ClaudeSettings(permissions: Permissions(allow: ["Bash(*)"]))
         let context = HealthCheckTestHelpers.makeContext(projectSettings: settings)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.first?.autoFix == nil)
     }
 }
 
-// MARK: - GlobalConfigSizeCheck Tests
+// MARK: - GlobalConfigSizeCheckTests
 
 @Suite("GlobalConfigSizeCheck Tests")
 struct GlobalConfigSizeCheckTests {
@@ -147,7 +147,7 @@ struct GlobalConfigSizeCheckTests {
     func flagsLargeConfig() {
         let size: Int64 = 6 * 1024 * 1024 // 6 MB
         let context = HealthCheckTestHelpers.makeContext(globalConfigFileSize: size)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.count == 1)
         #expect(findings.first?.severity == .warning)
@@ -158,7 +158,7 @@ struct GlobalConfigSizeCheckTests {
     func noFindingForSmall() {
         let size: Int64 = 1024 // 1 KB
         let context = HealthCheckTestHelpers.makeContext(globalConfigFileSize: size)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
@@ -166,13 +166,13 @@ struct GlobalConfigSizeCheckTests {
     @Test("No finding when size is unknown")
     func noFindingWhenUnknown() {
         let context = HealthCheckTestHelpers.makeContext(globalConfigFileSize: nil)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
 }
 
-// MARK: - MCPHardcodedSecretsCheck Tests
+// MARK: - MCPHardcodedSecretsCheckTests
 
 @Suite("MCPHardcodedSecretsCheck Tests")
 struct MCPHardcodedSecretsCheckTests {
@@ -183,7 +183,7 @@ struct MCPHardcodedSecretsCheckTests {
         let server = MCPServer(command: "npx", env: ["GITHUB_TOKEN": "ghp_1234567890abcdef"])
         let config = MCPConfig(mcpServers: ["github": server])
         let context = HealthCheckTestHelpers.makeContext(mcpConfig: config)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(!findings.isEmpty)
         #expect(findings.first?.severity == .warning)
@@ -194,7 +194,7 @@ struct MCPHardcodedSecretsCheckTests {
         let server = MCPServer(command: "npx", env: ["API_KEY": "some-long-api-key-value"])
         let config = MCPConfig(mcpServers: ["test": server])
         let context = HealthCheckTestHelpers.makeContext(mcpConfig: config)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(!findings.isEmpty)
     }
@@ -204,7 +204,7 @@ struct MCPHardcodedSecretsCheckTests {
         let server = MCPServer(command: "npx", env: ["NODE_ENV": "production"])
         let config = MCPConfig(mcpServers: ["test": server])
         let context = HealthCheckTestHelpers.makeContext(mcpConfig: config)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
@@ -216,7 +216,7 @@ struct MCPHardcodedSecretsCheckTests {
         ])
         let config = MCPConfig(mcpServers: ["remote": server])
         let context = HealthCheckTestHelpers.makeContext(mcpConfig: config)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(!findings.isEmpty)
     }
@@ -224,13 +224,13 @@ struct MCPHardcodedSecretsCheckTests {
     @Test("No findings when no MCP servers")
     func noFindingsNoServers() {
         let context = HealthCheckTestHelpers.makeContext()
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
 }
 
-// MARK: - LocalSettingsCheck Tests
+// MARK: - LocalSettingsCheckTests
 
 @Suite("LocalSettingsCheck Tests")
 struct LocalSettingsCheckTests {
@@ -239,7 +239,7 @@ struct LocalSettingsCheckTests {
     @Test("Suggests creating local settings when missing")
     func suggestsCreation() {
         let context = HealthCheckTestHelpers.makeContext(localSettingsExists: false)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.count == 1)
         #expect(findings.first?.severity == .suggestion)
@@ -249,13 +249,13 @@ struct LocalSettingsCheckTests {
     @Test("No finding when local settings exist")
     func noFindingWhenExists() {
         let context = HealthCheckTestHelpers.makeContext(localSettingsExists: true)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
 }
 
-// MARK: - MCPScopingCheck Tests
+// MARK: - MCPScopingCheckTests
 
 @Suite("MCPScopingCheck Tests")
 struct MCPScopingCheckTests {
@@ -270,7 +270,7 @@ struct MCPScopingCheckTests {
             legacyConfig: legacy,
             mcpConfigExists: false
         )
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.count == 1)
         #expect(findings.first?.severity == .suggestion)
@@ -285,7 +285,7 @@ struct MCPScopingCheckTests {
             legacyConfig: legacy,
             mcpConfigExists: true
         )
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
@@ -293,13 +293,13 @@ struct MCPScopingCheckTests {
     @Test("No finding when no global servers")
     func noFindingNoGlobalServers() {
         let context = HealthCheckTestHelpers.makeContext(mcpConfigExists: false)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
 }
 
-// MARK: - HookSuggestionsCheck Tests
+// MARK: - HookSuggestionsCheckTests
 
 @Suite("HookSuggestionsCheck Tests")
 struct HookSuggestionsCheckTests {
@@ -308,7 +308,7 @@ struct HookSuggestionsCheckTests {
     @Test("Suggests hooks when none configured")
     func suggestsHooks() {
         let context = HealthCheckTestHelpers.makeContext()
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.count == 1)
         #expect(findings.first?.severity == .suggestion)
@@ -321,13 +321,13 @@ struct HookSuggestionsCheckTests {
         ]
         let settings = ClaudeSettings(hooks: hooks)
         let context = HealthCheckTestHelpers.makeContext(projectSettings: settings)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
 }
 
-// MARK: - GoodPracticesCheck Tests
+// MARK: - GoodPracticesCheckTests
 
 @Suite("GoodPracticesCheck Tests")
 struct GoodPracticesCheckTests {
@@ -337,7 +337,7 @@ struct GoodPracticesCheckTests {
     func reportsEnvProtection() {
         let settings = ClaudeSettings(permissions: Permissions(deny: ["Read(.env)"]))
         let context = HealthCheckTestHelpers.makeContext(projectSettings: settings)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         let envFinding = findings.first { $0.title.contains("Sensitive files protected") }
         #expect(envFinding != nil)
@@ -347,7 +347,7 @@ struct GoodPracticesCheckTests {
     @Test("Reports good practice for local settings")
     func reportsLocalSettings() {
         let context = HealthCheckTestHelpers.makeContext(localSettingsExists: true)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         let localFinding = findings.first { $0.title.contains("Local settings") }
         #expect(localFinding != nil)
@@ -357,7 +357,7 @@ struct GoodPracticesCheckTests {
     @Test("Reports good practice for project MCP")
     func reportsProjectMCP() {
         let context = HealthCheckTestHelpers.makeContext(mcpConfigExists: true)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         let mcpFinding = findings.first { $0.title.contains("Project-scoped MCP") }
         #expect(mcpFinding != nil)
@@ -367,13 +367,13 @@ struct GoodPracticesCheckTests {
     @Test("No good practices for empty config")
     func noGoodPracticesEmpty() {
         let context = HealthCheckTestHelpers.makeContext()
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
 }
 
-// MARK: - Well-Configured Project Tests
+// MARK: - WellConfiguredProjectTests
 
 @Suite("Well-Configured Project Tests")
 struct WellConfiguredProjectTests {

--- a/Fig/Tests/OnboardingViewModelTests.swift
+++ b/Fig/Tests/OnboardingViewModelTests.swift
@@ -122,8 +122,6 @@ struct OnboardingViewModelTests {
         }
     }
 
-    // MARK: - State Properties
-
     @Suite("State Properties")
     struct StateProperties {
         @Test("isFirstStep is true only on welcome")

--- a/Fig/Tests/PluginTests.swift
+++ b/Fig/Tests/PluginTests.swift
@@ -1,0 +1,414 @@
+@testable import Fig
+import Foundation
+import Testing
+
+// MARK: - PluginTestFixtures
+
+enum PluginTestFixtures {
+    static let validManifestJSON = """
+    {
+        "id": "com.example.test-plugin",
+        "name": "Test Plugin",
+        "version": "1.0.0",
+        "author": {
+            "name": "Test Author",
+            "email": "test@example.com"
+        },
+        "summary": "A test plugin for unit testing",
+        "category": "health-checks",
+        "main": "init.lua",
+        "capabilities": ["health:register", "config:read:global"],
+        "hooks": [
+            { "event": "PreToolUse", "handler": "on_pre_tool" }
+        ]
+    }
+    """
+
+    static let minimalManifestJSON = """
+    {
+        "id": "minimal.plugin",
+        "name": "Minimal",
+        "version": "0.1.0",
+        "author": { "name": "Someone" },
+        "summary": "Minimal plugin",
+        "category": "other",
+        "main": "main.lua"
+    }
+    """
+
+    static let manifestWithUnknownFieldsJSON = """
+    {
+        "id": "com.example.future",
+        "name": "Future Plugin",
+        "version": "2.0.0",
+        "author": { "name": "Future Dev" },
+        "summary": "Plugin with future fields",
+        "category": "workflows",
+        "main": "future.lua",
+        "futureField": "should be preserved",
+        "anotherNewField": { "nested": true }
+    }
+    """
+
+    static let invalidCategoryJSON = """
+    {
+        "id": "com.example.invalid",
+        "name": "Invalid Category",
+        "version": "1.0.0",
+        "author": { "name": "Test" },
+        "summary": "Has invalid category",
+        "category": "not_a_real_category",
+        "main": "init.lua"
+    }
+    """
+}
+
+// MARK: - PluginManifestTests
+
+@Suite("PluginManifest Tests")
+struct PluginManifestTests {
+    @Test("Decodes valid manifest with all fields")
+    func decodeValidManifest() throws {
+        let data = try #require(PluginTestFixtures.validManifestJSON.data(using: .utf8))
+        let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
+
+        #expect(manifest.id == "com.example.test-plugin")
+        #expect(manifest.name == "Test Plugin")
+        #expect(manifest.version == "1.0.0")
+        #expect(manifest.author.name == "Test Author")
+        #expect(manifest.author.email == "test@example.com")
+        #expect(manifest.summary == "A test plugin for unit testing")
+        #expect(manifest.category == .healthChecks)
+        #expect(manifest.main == "init.lua")
+        #expect(manifest.capabilities?.count == 2)
+        #expect(manifest.hooks?.count == 1)
+        #expect(manifest.hooks?.first?.event == "PreToolUse")
+        #expect(manifest.hooks?.first?.handler == "on_pre_tool")
+    }
+
+    @Test("Decodes minimal manifest")
+    func decodeMinimalManifest() throws {
+        let data = try #require(PluginTestFixtures.minimalManifestJSON.data(using: .utf8))
+        let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
+
+        #expect(manifest.id == "minimal.plugin")
+        #expect(manifest.name == "Minimal")
+        #expect(manifest.version == "0.1.0")
+        #expect(manifest.author.name == "Someone")
+        #expect(manifest.author.email == nil)
+        #expect(manifest.category == .other)
+        #expect(manifest.main == "main.lua")
+        #expect(manifest.capabilities == nil)
+        #expect(manifest.hooks == nil)
+    }
+
+    @Test("Preserves unknown fields during round-trip")
+    func preserveUnknownFields() throws {
+        let data = try #require(PluginTestFixtures.manifestWithUnknownFieldsJSON.data(using: .utf8))
+        let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
+
+        // Verify basic fields
+        #expect(manifest.id == "com.example.future")
+        #expect(manifest.category == .workflows)
+
+        // Verify unknown fields are preserved
+        #expect(manifest.additionalProperties?["futureField"]?.value as? String == "should be preserved")
+
+        // Round-trip
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        let encoded = try encoder.encode(manifest)
+        let redecoded = try JSONDecoder().decode(PluginManifest.self, from: encoded)
+
+        #expect(redecoded.additionalProperties?["futureField"]?.value as? String == "should be preserved")
+    }
+
+    @Test("Decodes unknown category as other")
+    func decodeUnknownCategory() throws {
+        let data = try #require(PluginTestFixtures.invalidCategoryJSON.data(using: .utf8))
+        let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
+
+        // Unknown categories should decode as .other
+        #expect(manifest.category == .other)
+    }
+
+    @Test("Manifest is Equatable")
+    func manifestEquatable() throws {
+        let data = try #require(PluginTestFixtures.minimalManifestJSON.data(using: .utf8))
+        let manifest1 = try JSONDecoder().decode(PluginManifest.self, from: data)
+        let manifest2 = try JSONDecoder().decode(PluginManifest.self, from: data)
+
+        #expect(manifest1 == manifest2)
+    }
+
+    @Test("Manifest is Hashable")
+    func manifestHashable() throws {
+        let data = try #require(PluginTestFixtures.minimalManifestJSON.data(using: .utf8))
+        let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
+
+        var set = Set<PluginManifest>()
+        set.insert(manifest)
+        #expect(set.contains(manifest))
+    }
+}
+
+// MARK: - PluginCapabilityTests
+
+@Suite("PluginCapability Tests")
+struct PluginCapabilityTests {
+    @Test("Parses valid capability strings")
+    func parseValidCapabilities() {
+        let capabilities = PluginCapability.parse(capabilities: [
+            "health:register",
+            "config:read:global",
+            "fs:exists",
+        ])
+
+        #expect(capabilities.contains(.healthRegister))
+        #expect(capabilities.contains(.configReadGlobal))
+        #expect(capabilities.contains(.fsExists))
+        #expect(capabilities.count == 3)
+    }
+
+    @Test("Ignores unknown capability strings")
+    func ignoreUnknownCapabilities() {
+        let capabilities = PluginCapability.parse(capabilities: [
+            "health:register",
+            "unknown:capability",
+            "another:invalid:one",
+        ])
+
+        #expect(capabilities.contains(.healthRegister))
+        #expect(capabilities.count == 1)
+    }
+
+    @Test("Handles nil capabilities array")
+    func handleNilCapabilities() {
+        let capabilities = PluginCapability.parse(capabilities: nil)
+        #expect(capabilities.isEmpty)
+    }
+
+    @Test("Handles empty capabilities array")
+    func handleEmptyCapabilities() {
+        let capabilities = PluginCapability.parse(capabilities: [])
+        #expect(capabilities.isEmpty)
+    }
+
+    @Test("Identifies sensitive capabilities")
+    func identifySensitiveCapabilities() {
+        #expect(PluginCapability.configWriteProject.isSensitive == true)
+        #expect(PluginCapability.configWriteLocal.isSensitive == true)
+        #expect(PluginCapability.healthAutofix.isSensitive == true)
+        #expect(PluginCapability.fsReadProject.isSensitive == true)
+
+        #expect(PluginCapability.healthRegister.isSensitive == false)
+        #expect(PluginCapability.configReadGlobal.isSensitive == false)
+        #expect(PluginCapability.fsExists.isSensitive == false)
+    }
+
+    @Test("All capabilities have descriptions")
+    func allCapabilitiesHaveDescriptions() {
+        for capability in PluginCapability.allCases {
+            #expect(!capability.localizedDescription.isEmpty)
+            #expect(!capability.iconName.isEmpty)
+        }
+    }
+
+    @Test("Capabilities are comparable")
+    func capabilitiesComparable() {
+        let sorted = [
+            PluginCapability.fsExists,
+            PluginCapability.configReadGlobal,
+            PluginCapability.healthRegister,
+        ].sorted()
+
+        // Should be sorted by rawValue alphabetically
+        #expect(sorted[0] == .configReadGlobal)
+    }
+}
+
+// MARK: - PluginStateTests
+
+@Suite("PluginState Tests")
+struct PluginStateTests {
+    @Test("LoadedPlugin has correct computed properties")
+    func loadedPluginComputedProperties() throws {
+        let manifestData = try #require(PluginTestFixtures.validManifestJSON.data(using: .utf8))
+        let manifest = try JSONDecoder().decode(PluginManifest.self, from: manifestData)
+
+        var plugin = LoadedPlugin(
+            manifest: manifest,
+            path: URL(fileURLWithPath: "/test/path"),
+            state: .discovered,
+            grantedCapabilities: [.healthRegister]
+        )
+
+        #expect(plugin.id == "com.example.test-plugin")
+        #expect(plugin.isActive == false)
+        #expect(!plugin
+            .hasAllCapabilities) // Requested health:register and config:read:global, only granted health:register
+
+        // Change state to active
+        plugin.state = .active
+        #expect(plugin.isActive == true)
+
+        // Grant remaining capability
+        plugin.grantedCapabilities.insert(.configReadGlobal)
+        #expect(plugin.hasAllCapabilities)
+        #expect(plugin.pendingCapabilities.isEmpty)
+    }
+
+    @Test("PluginLifecycleState encodes and decodes")
+    func lifecycleStateRoundTrip() throws {
+        for state in [
+            PluginLifecycleState.discovered,
+            .loading,
+            .active,
+            .error,
+            .disabled,
+            .unloading,
+        ] {
+            let encoded = try JSONEncoder().encode(state)
+            let decoded = try JSONDecoder().decode(PluginLifecycleState.self, from: encoded)
+            #expect(state == decoded)
+        }
+    }
+
+    @Test("PluginHookResult stores execution data")
+    func hookResultProperties() {
+        let result = PluginHookResult(
+            pluginId: "test.plugin",
+            hookEvent: "PreToolUse",
+            success: true,
+            output: ["action": AnyCodable("allow")],
+            duration: 0.05
+        )
+
+        #expect(result.pluginId == "test.plugin")
+        #expect(result.hookEvent == "PreToolUse")
+        #expect(result.success == true)
+        #expect(result.output?["action"]?.value as? String == "allow")
+        #expect(result.duration == 0.05)
+        #expect(result.error == nil)
+    }
+
+    @Test("HookExecutionContext converts to dictionary")
+    func hookContextToDictionary() {
+        let context = HookExecutionContext(
+            event: "PreToolUse",
+            toolName: "Bash",
+            toolInput: "npm test",
+            projectPath: URL(fileURLWithPath: "/project"),
+            additionalData: ["extra": AnyCodable("value")]
+        )
+
+        let dict = context.toDictionary()
+
+        #expect(dict["event"] as? String == "PreToolUse")
+        #expect(dict["toolName"] as? String == "Bash")
+        #expect(dict["toolInput"] as? String == "npm test")
+        #expect(dict["projectPath"] as? String == "/project")
+        #expect(dict["extra"] as? String == "value")
+        #expect(dict["toolOutput"] == nil) // Not set
+    }
+}
+
+// MARK: - PluginInstallationStateTests
+
+@Suite("PluginInstallationState Tests")
+struct PluginInstallationStateTests {
+    @Test("Installation state tracks disabled plugins")
+    func disabledPluginTracking() {
+        var state = PluginInstallationState()
+
+        #expect(state.isDisabled("test.plugin") == false)
+
+        state.disabledPlugins.insert("test.plugin")
+        #expect(state.isDisabled("test.plugin") == true)
+
+        state.disabledPlugins.remove("test.plugin")
+        #expect(state.isDisabled("test.plugin") == false)
+    }
+
+    @Test("Installation state tracks granted capabilities")
+    func grantedCapabilitiesTracking() {
+        var state = PluginInstallationState()
+
+        #expect(state.capabilities(for: "test.plugin").isEmpty)
+
+        state.grantedCapabilities["test.plugin"] = ["health:register", "config:read:global"]
+        let capabilities = state.capabilities(for: "test.plugin")
+
+        #expect(capabilities.contains(.healthRegister))
+        #expect(capabilities.contains(.configReadGlobal))
+        #expect(capabilities.count == 2)
+    }
+
+    @Test("Installation state encodes and decodes")
+    func installationStateRoundTrip() throws {
+        var state = PluginInstallationState()
+        state.disabledPlugins = ["disabled.plugin"]
+        state.grantedCapabilities = ["test.plugin": ["health:register"]]
+        state.plugins = [
+            "test.plugin": InstalledPluginInfo(
+                pluginId: "test.plugin",
+                version: "1.0.0",
+                installedAt: Date(),
+                installPath: "test.plugin",
+                source: .builtin
+            ),
+        ]
+
+        let encoded = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(PluginInstallationState.self, from: encoded)
+
+        #expect(decoded.disabledPlugins.contains("disabled.plugin"))
+        #expect(decoded.grantedCapabilities["test.plugin"]?.contains("health:register") == true)
+        #expect(decoded.plugins["test.plugin"]?.version == "1.0.0")
+    }
+}
+
+// MARK: - PluginErrorTests
+
+@Suite("PluginError Tests")
+struct PluginErrorTests {
+    @Test("All errors have descriptions")
+    func allErrorsHaveDescriptions() {
+        let errors: [PluginError] = [
+            .pluginNotFound(id: "test"),
+            .manifestMissing(path: "/path"),
+            .manifestInvalid(path: "/path", reason: "bad json"),
+            .loadFailed(id: "test", reason: "error"),
+            .executionFailed(id: "test", function: "init", reason: "error"),
+            .securityViolation(reason: "unsafe"),
+            .functionNotFound(name: "missing"),
+            .permissionDenied(capability: "write"),
+            .timeout(id: "test", function: "slow"),
+            .luaError(message: "syntax error"),
+            .versionIncompatible(pluginId: "test", required: "2.0", current: "1.0"),
+            .dependencyMissing(pluginId: "test", dependencyId: "dep"),
+            .alreadyLoaded(id: "test"),
+            .installFailed(reason: "network"),
+            .uninstallFailed(id: "test", reason: "locked"),
+            .checksumMismatch(expected: "abc", actual: "xyz"),
+            .signatureInvalid(reason: "expired"),
+            .networkError(reason: "timeout"),
+        ]
+
+        for error in errors {
+            #expect(error.errorDescription != nil)
+            #expect(error.recoverySuggestion != nil)
+            #expect(error.failureReason != nil)
+        }
+    }
+
+    @Test("Errors are equatable")
+    func errorsEquatable() {
+        let error1 = PluginError.pluginNotFound(id: "test")
+        let error2 = PluginError.pluginNotFound(id: "test")
+        let error3 = PluginError.pluginNotFound(id: "other")
+
+        #expect(error1 == error2)
+        #expect(error1 != error3)
+    }
+}

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -45,6 +45,15 @@ export default defineConfig({
 					],
 				},
 				{
+					label: 'Plugins',
+					items: [
+						{ label: 'Plugin System Overview', slug: 'plugins/overview' },
+						{ label: 'Built-in Plugins', slug: 'plugins/built-in' },
+						{ label: 'Creating Plugins', slug: 'plugins/creating-plugins' },
+						{ label: 'Plugin API Reference', slug: 'plugins/api-reference' },
+					],
+				},
+				{
 					label: 'Reference',
 					items: [
 						{ label: 'Configuration Files', slug: 'reference/config-files' },

--- a/docs/src/content/docs/configuration/health-checks.mdx
+++ b/docs/src/content/docs/configuration/health-checks.mdx
@@ -3,7 +3,13 @@ title: Config Health Checks
 description: Validate your Claude Code configuration and find issues.
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 Fig automatically validates your Claude Code configuration and highlights potential issues, security concerns, and improvement opportunities.
+
+<Aside type="tip">
+Health checks are powered by Fig's [Lua plugin system](/fig/plugins/overview/). You can create custom health checks for your own projects—see [Creating Plugins](/fig/plugins/creating-plugins/) to learn how.
+</Aside>
 
 ## Severity Levels
 

--- a/docs/src/content/docs/plugins/api-reference.mdx
+++ b/docs/src/content/docs/plugins/api-reference.mdx
@@ -1,0 +1,371 @@
+---
+title: Plugin API Reference
+description: Complete reference for the Fig plugin Lua API.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+This page documents all modules and functions available to Fig plugins through the `fig.*` Lua API.
+
+## API Modules
+
+| Module | Capabilities Required | Description |
+|--------|----------------------|-------------|
+| `fig.version` | None | Fig version information |
+| `fig.log` | None | Logging functions |
+| `fig.config` | `config:read:*`, `config:write:*` | Configuration access |
+| `fig.health` | `health:register`, `health:findings` | Health check registration |
+| `fig.preset` | `preset:register` | Permission preset registration |
+| `fig.fs` | `fs:read:project`, `fs:exists` | Sandboxed file access |
+
+---
+
+## fig.version
+
+Version information about Fig and the plugin API.
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `fig.version.app` | string | Fig application version (e.g., `"1.0.0"`) |
+| `fig.version.build` | string | Build number |
+| `fig.version.api` | string | Plugin API version (e.g., `"1.0"`) |
+
+### Example
+
+```lua
+fig.log.info("Running on Fig " .. fig.version.app)
+```
+
+---
+
+## fig.log
+
+Logging functions for debugging and diagnostics.
+
+<Aside type="note">
+All log messages are automatically prefixed with your plugin ID for easy identification.
+</Aside>
+
+### Functions
+
+#### fig.log.debug(message)
+
+Log a debug message.
+
+```lua
+fig.log.debug("Processing rule: " .. rule)
+```
+
+#### fig.log.info(message)
+
+Log an informational message.
+
+```lua
+fig.log.info("Plugin loaded successfully")
+```
+
+#### fig.log.warning(message)
+
+Log a warning message.
+
+```lua
+fig.log.warning("Deprecated configuration detected")
+```
+
+#### fig.log.error(message)
+
+Log an error message.
+
+```lua
+fig.log.error("Failed to parse configuration")
+```
+
+---
+
+## fig.config
+
+Read and write Claude Code configuration.
+
+<Aside type="caution">
+Write operations require sensitive capabilities (`config:write:project` or `config:write:local`) and will prompt for user approval.
+</Aside>
+
+### Functions
+
+#### fig.config.getGlobal(key)
+
+**Requires:** `config:read:global`
+
+Read a value from global settings (`~/.claude/settings.json`).
+
+```lua
+local value = fig.config.getGlobal("permissions")
+```
+
+#### fig.config.getProject(key)
+
+**Requires:** `config:read:project`
+
+Read a value from project settings (`.claude/settings.json`).
+
+```lua
+local hooks = fig.config.getProject("hooks")
+```
+
+#### fig.config.setProject(key, value)
+
+**Requires:** `config:write:project`
+
+Write a value to project settings.
+
+```lua
+fig.config.setProject("env", { MY_VAR = "value" })
+```
+
+#### fig.config.setLocal(key, value)
+
+**Requires:** `config:write:local`
+
+Write a value to local settings (`.claude/settings.local.json`).
+
+```lua
+fig.config.setLocal("env", { DEBUG = "true" })
+```
+
+---
+
+## fig.health
+
+Health check registration and finding creation.
+
+### Functions
+
+#### fig.health.registerCheck(id, checkFunction)
+
+**Requires:** `health:register`
+
+Register a health check function.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string | Unique identifier for this check |
+| `checkFunction` | function | Function receiving context, returning findings array |
+
+```lua
+fig.health.registerCheck("MyCheck", function(context)
+    local findings = {}
+    -- ... analyze context ...
+    return findings
+end)
+```
+
+#### fig.health.finding(options)
+
+**Requires:** `health:findings`
+
+Create a health check finding.
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `severity` | string | Yes | Severity level (use `fig.health.severity.*`) |
+| `title` | string | Yes | Short title for the finding |
+| `description` | string | Yes | Detailed description |
+| `autoFix` | table | No | Auto-fix action (use `fig.health.autoFix.*`) |
+
+```lua
+fig.health.finding({
+    severity = fig.health.severity.WARNING,
+    title = "Issue detected",
+    description = "Description of the issue and how to fix it",
+    autoFix = fig.health.autoFix.addRule("Read(.env)")
+})
+```
+
+### Constants
+
+#### fig.health.severity
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `CRITICAL` | `"critical"` | Security risk |
+| `WARNING` | `"warning"` | Configuration problem |
+| `SUGGESTION` | `"suggestion"` | Improvement recommendation |
+| `INFO` | `"info"` | Positive feedback |
+
+### Auto-Fix Helpers
+
+#### fig.health.autoFix.addRule(pattern)
+
+Create an auto-fix that adds a rule to the deny list.
+
+```lua
+autoFix = fig.health.autoFix.addRule("Read(.env)")
+```
+
+#### fig.health.autoFix.createLocalSettings()
+
+Create an auto-fix that creates `settings.local.json`.
+
+```lua
+autoFix = fig.health.autoFix.createLocalSettings()
+```
+
+---
+
+## fig.preset
+
+Permission preset registration.
+
+### Functions
+
+#### fig.preset.registerPermissionPreset(options)
+
+**Requires:** `preset:register`
+
+Register a permission preset for the UI.
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `id` | string | Yes | Unique preset identifier |
+| `name` | string | Yes | Display name |
+| `category` | string | No | Category for grouping |
+| `rules` | table | Yes | Array of rule objects |
+
+```lua
+fig.preset.registerPermissionPreset({
+    id = "security-baseline",
+    name = "Security Baseline",
+    category = "security",
+    rules = {
+        { rule = "Read(.env)", type = "deny" },
+        { rule = "Read(secrets/**)", type = "deny" },
+        { rule = "Bash(rm -rf *)", type = "deny" }
+    }
+})
+```
+
+---
+
+## fig.fs
+
+Sandboxed filesystem access.
+
+<Aside type="caution">
+File access is restricted to files within your plugin's directory for security.
+</Aside>
+
+### Functions
+
+#### fig.fs.exists(path)
+
+**Requires:** `fs:exists`
+
+Check if a file exists within the plugin directory.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `path` | string | Relative path within plugin directory |
+
+```lua
+if fig.fs.exists("config.json") then
+    fig.log.info("Config file found")
+end
+```
+
+#### fig.fs.readFile(path)
+
+**Requires:** `fs:read:project`
+
+Read a file's contents within the plugin directory.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `path` | string | Relative path within plugin directory |
+
+Returns `nil` if the file doesn't exist or is outside the plugin directory.
+
+```lua
+local contents = fig.fs.readFile("data.json")
+if contents then
+    -- parse contents
+end
+```
+
+---
+
+## Health Check Context
+
+The context table passed to health check functions contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `denyRules` | table | Array of deny rules from all config sources |
+| `allowRules` | table | Array of allow rules from all config sources |
+| `mcpServers` | table | Map of server name → `{ env = {}, headers = {} }` |
+| `localSettingsExists` | boolean | `true` if `settings.local.json` exists |
+| `mcpConfigExists` | boolean | `true` if `.mcp.json` exists |
+| `globalConfigFileSize` | number | Size of `~/.claude.json` in bytes (or `nil`) |
+| `hasGlobalMCPServers` | boolean | `true` if global MCP servers configured |
+| `hasHooks` | boolean | `true` if any hooks configured |
+
+### Example Context Usage
+
+```lua
+fig.health.registerCheck("FullExample", function(context)
+    local findings = {}
+
+    -- Check deny rules
+    for _, rule in ipairs(context.denyRules) do
+        fig.log.debug("Found deny rule: " .. rule)
+    end
+
+    -- Check MCP servers
+    for name, server in pairs(context.mcpServers) do
+        if server.env then
+            for key, value in pairs(server.env) do
+                -- Check for hardcoded secrets...
+            end
+        end
+    end
+
+    -- Check boolean flags
+    if not context.localSettingsExists then
+        table.insert(findings, fig.health.finding({
+            severity = fig.health.severity.SUGGESTION,
+            title = "No local settings",
+            description = "Consider creating settings.local.json",
+            autoFix = fig.health.autoFix.createLocalSettings()
+        }))
+    end
+
+    return findings
+end)
+```
+
+---
+
+## Capabilities Reference
+
+| Capability | Description | Sensitive |
+|------------|-------------|-----------|
+| `config:read:global` | Read global Claude Code settings | No |
+| `config:read:project` | Read project-level settings | No |
+| `config:read:mcp` | Read MCP server configurations | No |
+| `config:write:project` | Modify project settings | **Yes** |
+| `config:write:local` | Modify local settings | **Yes** |
+| `health:register` | Register health checks | No |
+| `health:findings` | Create health check findings | No |
+| `health:autofix` | Provide automatic fixes | **Yes** |
+| `preset:register` | Register permission presets | No |
+| `mcp:template:register` | Register MCP server templates | No |
+| `hook:template:register` | Register hook templates | No |
+| `event:subscribe` | Subscribe to lifecycle events | No |
+| `ui:notification` | Show user notifications | No |
+| `fs:read:project` | Read files in plugin directory | **Yes** |
+| `fs:exists` | Check if files exist | No |
+
+<Aside type="note">
+**Sensitive capabilities** require explicit user approval before the plugin can use them.
+</Aside>

--- a/docs/src/content/docs/plugins/built-in.mdx
+++ b/docs/src/content/docs/plugins/built-in.mdx
@@ -1,0 +1,143 @@
+---
+title: Built-in Plugins
+description: Health checks and features included with Fig out of the box.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Fig ships with three built-in Lua plugins that provide comprehensive health check coverage for your Claude Code configuration.
+
+## Security Plugin
+
+**Plugin ID:** `com.fig.builtin.security`
+
+The security plugin checks for common security issues in your Claude Code configuration.
+
+### Checks Included
+
+| Check | Severity | Description |
+|-------|----------|-------------|
+| **Deny List Security** | Critical | Ensures `.env` files and `secrets/` directories are protected with deny rules |
+| **Broad Allow Rules** | Warning | Flags overly permissive rules like `Bash(*)`, `Read(*)`, `Write(*)`, `Edit(*)` |
+| **MCP Hardcoded Secrets** | Warning | Detects API keys, tokens, and secrets hardcoded in MCP server configurations |
+| **Global Config Size** | Warning | Warns when `~/.claude.json` exceeds 5 MB, indicating potential performance issues |
+
+### Example Findings
+
+**Deny List Security** triggers when your deny list doesn't include protection for sensitive files:
+
+```
+❌ .env files not in deny list
+
+Environment files often contain secrets like API keys and passwords.
+Add a deny rule to prevent Claude from reading them.
+
+Auto-fix: Add Read(.env) to deny list
+```
+
+**Broad Allow Rules** triggers for overly permissive patterns:
+
+```
+⚠️ Overly broad allow rule: Bash(*)
+
+Allows any Bash command without restriction. Consider using
+more specific patterns to limit what Claude can access.
+```
+
+---
+
+## Suggestions Plugin
+
+**Plugin ID:** `com.fig.builtin.suggestions`
+
+The suggestions plugin recommends configuration improvements to enhance your Claude Code setup.
+
+### Checks Included
+
+| Check | Severity | Description |
+|-------|----------|-------------|
+| **Local Settings** | Suggestion | Recommends creating `settings.local.json` for personal overrides |
+| **MCP Scoping** | Suggestion | Suggests scoping MCP servers to projects when only global servers exist |
+| **Hook Suggestions** | Suggestion | Recommends hooks when none are configured |
+
+### Example Findings
+
+**Local Settings** triggers when no local settings file exists:
+
+```
+💡 No settings.local.json
+
+Create a local settings file for personal overrides that won't be
+committed to version control. This is useful for developer-specific
+environment variables or permission tweaks.
+
+Auto-fix: Create settings.local.json
+```
+
+**MCP Scoping** triggers when you have global MCP servers but no project-level configuration:
+
+```
+💡 Global MCP servers without project scoping
+
+You have global MCP servers configured but no project-level .mcp.json.
+Consider creating a project-scoped MCP configuration for better isolation.
+```
+
+---
+
+## Good Practices Plugin
+
+**Plugin ID:** `com.fig.builtin.good-practices`
+
+The good practices plugin provides positive feedback about well-configured aspects of your setup.
+
+### Checks Included
+
+| Check | Severity | Description |
+|-------|----------|-------------|
+| **Sensitive Files Protected** | Good | Confirms `.env` files are in the deny list |
+| **Secrets Directory Protected** | Good | Confirms `secrets/` is in the deny list |
+| **Local Settings Configured** | Good | Confirms `settings.local.json` exists |
+| **Project-Scoped MCP Servers** | Good | Confirms project-level MCP configuration |
+| **Hooks Configured** | Good | Confirms lifecycle hooks are set up |
+| **Scoped Permission Rules** | Good | Confirms use of path-specific permission patterns |
+
+### Example Findings
+
+```
+✓ Sensitive files protected
+
+Your deny list includes rules to protect .env files from being read.
+```
+
+```
+✓ Project-scoped MCP servers
+
+MCP servers are configured at the project level for better isolation.
+```
+
+---
+
+## Capabilities Required
+
+All built-in plugins request the following capabilities:
+
+| Capability | Purpose |
+|------------|---------|
+| `health:register` | Register health check functions |
+| `health:findings` | Create health check findings |
+| `config:read:global` | Read global settings for analysis |
+| `config:read:project` | Read project settings for analysis |
+
+<Aside type="tip">
+Built-in plugins are automatically granted their required capabilities since they ship with Fig and are trusted.
+</Aside>
+
+## Viewing Health Check Results
+
+Open the **Health** tab (**Cmd+7**) in any project's detail view to see findings from all plugins. Results are sorted by severity, with critical issues first.
+
+Each finding includes:
+- A clear description of the issue
+- Why it matters
+- Guidance on resolution (and auto-fix where available)

--- a/docs/src/content/docs/plugins/creating-plugins.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins.mdx
@@ -1,0 +1,255 @@
+---
+title: Creating Plugins
+description: Build custom Lua plugins to extend Fig's functionality.
+---
+
+import { Steps, Aside } from '@astrojs/starlight/components';
+
+Learn how to create custom Lua plugins for Fig to add your own health checks, permission presets, and more.
+
+## Plugin Structure
+
+A Fig plugin is a directory containing at minimum:
+
+```
+my-plugin/
+├── plugin.json    # Plugin manifest (required)
+└── init.lua       # Entry point (required)
+```
+
+## Plugin Manifest
+
+The `plugin.json` file describes your plugin's metadata and requirements:
+
+```json
+{
+  "id": "com.example.my-plugin",
+  "name": "My Custom Plugin",
+  "version": "1.0.0",
+  "author": {
+    "name": "Your Name",
+    "email": "you@example.com"
+  },
+  "summary": "A brief description (max 140 characters)",
+  "description": "A longer description of what your plugin does.",
+  "category": "health-checks",
+  "main": "init.lua",
+  "capabilities": [
+    "health:register",
+    "health:findings"
+  ]
+}
+```
+
+### Manifest Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | Unique identifier (reverse domain notation recommended) |
+| `name` | Yes | Human-readable name |
+| `version` | Yes | Semantic version (e.g., `1.0.0`) |
+| `author` | Yes | Object with `name` and optional `email` |
+| `summary` | Yes | Brief description (max 140 characters) |
+| `description` | No | Longer description |
+| `category` | Yes | One of: `health-checks`, `presets`, `workflows`, `mcp-templates`, `other` |
+| `main` | Yes | Entry point Lua file |
+| `capabilities` | No | Array of required capabilities |
+
+## Creating a Health Check Plugin
+
+<Steps>
+
+1. Create the plugin directory
+
+   ```bash
+   mkdir -p ~/.fig/plugins/my-health-check
+   ```
+
+2. Create `plugin.json`
+
+   ```json
+   {
+     "id": "com.example.my-health-check",
+     "name": "My Health Check",
+     "version": "1.0.0",
+     "author": { "name": "Your Name" },
+     "summary": "Custom health checks for my projects",
+     "category": "health-checks",
+     "main": "init.lua",
+     "capabilities": [
+       "health:register",
+       "health:findings",
+       "config:read:project"
+     ]
+   }
+   ```
+
+3. Create `init.lua`
+
+   ```lua
+   -- Register a custom health check
+   fig.health.registerCheck("MyCustomCheck", function(context)
+       local findings = {}
+
+       -- Check for a specific condition
+       local allowRules = context.allowRules or {}
+
+       for _, rule in ipairs(allowRules) do
+           if string.find(rule, "dangerous", 1, true) then
+               table.insert(findings, fig.health.finding({
+                   severity = fig.health.severity.WARNING,
+                   title = "Potentially dangerous allow rule",
+                   description = "Found an allow rule containing 'dangerous': " .. rule
+               }))
+           end
+       end
+
+       return findings
+   end)
+
+   fig.log.info("My health check plugin loaded!")
+   ```
+
+4. Restart Fig to discover the new plugin
+
+</Steps>
+
+## Health Check Context
+
+Your health check function receives a `context` table with the following fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `denyRules` | table | Array of all deny rules from all config sources |
+| `allowRules` | table | Array of all allow rules from all config sources |
+| `mcpServers` | table | Map of MCP server name → server config |
+| `localSettingsExists` | boolean | Whether `settings.local.json` exists |
+| `mcpConfigExists` | boolean | Whether `.mcp.json` exists |
+| `globalConfigFileSize` | number | Size of `~/.claude.json` in bytes |
+| `hasGlobalMCPServers` | boolean | Whether global MCP servers are configured |
+| `hasHooks` | boolean | Whether any hooks are configured |
+
+## Creating Findings
+
+Use `fig.health.finding()` to create findings:
+
+```lua
+fig.health.finding({
+    severity = fig.health.severity.WARNING,
+    title = "Short title",
+    description = "Detailed description of the issue",
+    autoFix = fig.health.autoFix.addRule("Read(.env)")  -- optional
+})
+```
+
+### Severity Levels
+
+| Constant | Description |
+|----------|-------------|
+| `fig.health.severity.CRITICAL` | Security risk requiring immediate attention |
+| `fig.health.severity.WARNING` | Configuration issue that could cause problems |
+| `fig.health.severity.SUGGESTION` | Recommendation for improvement |
+| `fig.health.severity.INFO` | Positive feedback about good practices |
+
+### Auto-Fix Options
+
+| Function | Description |
+|----------|-------------|
+| `fig.health.autoFix.addRule(pattern)` | Add a rule to the deny list |
+| `fig.health.autoFix.createLocalSettings()` | Create `settings.local.json` |
+
+## Plugin Lifecycle Functions
+
+Optionally implement these functions for lifecycle hooks:
+
+```lua
+-- Called after plugin is loaded
+function plugin_init()
+    fig.log.info("Plugin initialized")
+end
+
+-- Called before plugin is unloaded
+function plugin_cleanup()
+    fig.log.info("Plugin cleaning up")
+end
+```
+
+## Logging
+
+Use the `fig.log` module for debugging:
+
+```lua
+fig.log.debug("Debug message")
+fig.log.info("Info message")
+fig.log.warning("Warning message")
+fig.log.error("Error message")
+```
+
+<Aside type="tip">
+Log messages appear in Fig's console with your plugin ID prefix, making it easy to identify which plugin generated them.
+</Aside>
+
+## Testing Your Plugin
+
+1. Place your plugin in `~/.fig/plugins/`
+2. Restart Fig to discover the plugin
+3. Open a project and navigate to the **Health** tab
+4. Your custom health check findings should appear
+
+## Security Considerations
+
+<Aside type="caution">
+Plugins run in a sandboxed environment. The following restrictions apply:
+
+- No shell command execution (`os.execute` removed)
+- No arbitrary file I/O (`io.*` removed)
+- No debug introspection (`debug.*` removed)
+- No loading external Lua files (`loadfile`, `dofile` removed)
+- File access limited to plugin directory
+</Aside>
+
+## Example: Complete Health Check Plugin
+
+Here's a complete example that checks for common issues:
+
+```lua
+-- init.lua for com.example.project-standards
+
+-- Check for README.md mention in CLAUDE.md
+fig.health.registerCheck("ClaudeDocumentation", function(context)
+    local findings = {}
+
+    -- This is a suggestion-level check
+    if not context.hasHooks then
+        table.insert(findings, fig.health.finding({
+            severity = fig.health.severity.SUGGESTION,
+            title = "Consider adding pre-commit hooks",
+            description = "Hooks can run formatters and linters automatically. " ..
+                "This helps maintain code quality when Claude makes changes."
+        }))
+    end
+
+    return findings
+end)
+
+-- Check for overly permissive network access
+fig.health.registerCheck("NetworkPermissions", function(context)
+    local findings = {}
+    local allowRules = context.allowRules or {}
+
+    for _, rule in ipairs(allowRules) do
+        if string.find(rule, "WebFetch(*)", 1, true) then
+            table.insert(findings, fig.health.finding({
+                severity = fig.health.severity.WARNING,
+                title = "Unrestricted web access allowed",
+                description = "The rule '" .. rule .. "' allows fetching any URL. " ..
+                    "Consider restricting to specific domains."
+            }))
+        end
+    end
+
+    return findings
+end)
+
+fig.log.info("Project standards plugin loaded")
+```

--- a/docs/src/content/docs/plugins/overview.mdx
+++ b/docs/src/content/docs/plugins/overview.mdx
@@ -1,0 +1,77 @@
+---
+title: Plugin System Overview
+description: Extend Fig with Lua plugins for custom health checks, presets, and automation.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Fig includes a powerful Lua-based plugin system that enables third-party extensions for health checks, permission presets, MCP templates, and more.
+
+## What Are Plugins?
+
+Plugins are self-contained Lua scripts that extend Fig's functionality. They can:
+
+- **Register custom health checks** to validate your Claude Code configuration
+- **Contribute permission presets** for common use cases
+- **Register MCP server templates** for quick setup
+- **Subscribe to lifecycle events** for automation
+
+## Security Model
+
+Fig's plugin system is built with security in mind:
+
+| Feature | Description |
+|---------|-------------|
+| **Sandboxed Execution** | Plugins run in a restricted Lua environment with dangerous functions removed |
+| **Capability-Based Permissions** | Plugins must declare required capabilities and sensitive operations require user approval |
+| **File Access Restrictions** | Plugins can only access files within their own directory |
+
+<Aside type="note">
+Dangerous Lua functions like `os.execute`, `io.*`, `debug.*`, `loadfile`, and `dofile` are completely removed from the sandbox.
+</Aside>
+
+## Plugin Locations
+
+Fig searches for plugins in the following locations (in order of precedence):
+
+1. **Built-in plugins** — Bundled with Fig in `Resources/Plugins/`
+2. **User plugins** — `~/.fig/plugins/`
+3. **App Support plugins** — `~/Library/Application Support/Fig/plugins/`
+
+## Plugin Lifecycle
+
+Plugins go through the following states:
+
+```
+discovered → loading → active
+                ↓
+              error
+                ↓
+            disabled
+```
+
+| State | Description |
+|-------|-------------|
+| **Discovered** | Plugin found but not yet loaded |
+| **Loading** | Plugin is being initialized |
+| **Active** | Plugin loaded and running |
+| **Error** | Plugin encountered an error during load or execution |
+| **Disabled** | Plugin disabled by user |
+
+## Built-in Plugins
+
+Fig ships with three built-in plugins that provide core health check functionality:
+
+- **Security Checks** (`com.fig.builtin.security`) — Validates security best practices
+- **Configuration Suggestions** (`com.fig.builtin.suggestions`) — Recommends configuration improvements
+- **Good Practices** (`com.fig.builtin.good-practices`) — Confirms positive configuration patterns
+
+See [Built-in Plugins](/fig/plugins/built-in/) for details on each plugin's checks.
+
+## Getting Started
+
+To learn more about the plugin system:
+
+- [Built-in Plugins](/fig/plugins/built-in/) — What's included out of the box
+- [Creating Plugins](/fig/plugins/creating-plugins/) — Build your own plugins
+- [Plugin API Reference](/fig/plugins/api-reference/) — Complete API documentation


### PR DESCRIPTION
## Summary

Implement Phase 1 and Phase 3 of the Lua plugin system for Fig, enabling extensibility through third-party Lua plugins with a focus on health checks:

- **Phase 1**: Core Lua infrastructure with sandboxed VM and plugin lifecycle management
- **Phase 3**: Migration of built-in health checks to Lua plugins for dogfooding

## Architecture

```mermaid
graph TB
    subgraph "Plugin System"
        PM[PluginManager] --> LR[LuaRuntime]
        LR --> SB[Sandbox]
        PM --> PD[PluginDiscovery]
        PM --> PC[PluginConfig]
    end

    subgraph "API Surface"
        LR --> FC[fig.config]
        LR --> FH[fig.health]
        LR --> FP[fig.preset]
        LR --> FE[fig.event]
    end

    subgraph "Built-in Plugins"
        BPS["builtin-security.lua<br/>builtin-suggestions.lua<br/>builtin-good-practices.lua"]
    end

    subgraph "Existing Fig"
        HC[HealthCheckService]
    end

    PM --> HC
    PM --> BPS
    HC --> PluginChecks["Execute Lua Checks"]
```

## Changes

### Core Infrastructure
- Added `SwiftyLua` dependency for Lua VM embedding
- Created `LuaSandbox`: Secure Lua virtual machine with dangerous functions removed
- Implemented `LuaPluginService`: Actor-based plugin lifecycle management (discover, load, unload, execute hooks)
- Added `LuaFigAPI`: Bridge exposing `fig.config`, `fig.health`, `fig.preset`, `fig.event`, `fig.fs` modules to plugins

### Plugin Models
- `PluginManifest`: Plugin metadata with forward-compatible JSON handling
- `PluginCapability`: Capability-based permissions (config:read, config:write, health:register, fs:read, etc.)
- `PluginState`: Lifecycle states (discovered, loading, active, error, disabled, unloading)
- `PluginError`: Comprehensive error types for plugin operations

### Health Check Migration
- Created 3 built-in Lua plugins in `Resources/Plugins/`:
  - **builtin-security**: DenyListSecurity, BroadAllowRules, MCPHardcodedSecrets, GlobalConfigSize checks
  - **builtin-suggestions**: LocalSettings, MCPScoping, HookSuggestions checks
  - **builtin-good-practices**: GoodPractices check
- Added `PluginHealthCheckAdapter`: Converts Lua findings to Swift `Finding` types
- Extended `ConfigHealthCheckService` with `runAllChecksAsync()` to include plugin checks

### Testing
- 414 lines of comprehensive plugin tests covering manifests, capabilities, state, and errors
- All 163 tests passing

## Test Plan

- [x] Build succeeds with new Lua plugin system
- [x] All 163 tests pass (new plugin tests + existing suite)
- [x] Plugin discovery finds built-in plugins
- [x] Health check context properly marshals to Lua tables
- [x] Lua findings parse correctly back to Swift types
- [x] Both Swift and Lua health checks execute together