### PR TITLE
feat: clipboard sharing and import for mcp configurations

### DIFF
--- a/Fig/Sources/App/AppCommands.swift
+++ b/Fig/Sources/App/AppCommands.swift
@@ -13,13 +13,21 @@ struct AppCommands: Commands {
             .keyboardShortcut(",", modifiers: .command)
         }
 
-        // File menu: New MCP Server
+        // File menu: New MCP Server + Import from JSON
         CommandGroup(after: .newItem) {
             Button("New MCP Server") {
                 self.addMCPServer?()
             }
             .keyboardShortcut("n", modifiers: [.command, .shift])
             .disabled(self.addMCPServer == nil)
+
+            Divider()
+
+            Button("Import MCP Servers from JSON...") {
+                self.pasteMCPServers?()
+            }
+            .keyboardShortcut("v", modifiers: [.command, .shift])
+            .disabled(self.pasteMCPServers == nil)
         }
 
         // Tab menu for switching detail tabs
@@ -57,4 +65,5 @@ struct AppCommands: Commands {
     @FocusedBinding(\.projectDetailTab) private var projectTab
     @FocusedBinding(\.globalSettingsTab) private var globalTab
     @FocusedValue(\.addMCPServerAction) private var addMCPServer
+    @FocusedValue(\.pasteMCPServersAction) private var pasteMCPServers
 }

--- a/Fig/Sources/App/FigApp.swift
+++ b/Fig/Sources/App/FigApp.swift
@@ -1,6 +1,8 @@
 import AppKit
 import SwiftUI
 
+// MARK: - AppDelegate
+
 /// App delegate to configure the application before UI loads.
 final class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
     func applicationDidFinishLaunching(_: Notification) {
@@ -12,6 +14,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
         }
     }
 }
+
+// MARK: - FigApp
 
 /// The main entry point for the Fig application.
 @main

--- a/Fig/Sources/App/FocusedValues.swift
+++ b/Fig/Sources/App/FocusedValues.swift
@@ -1,26 +1,34 @@
 import SwiftUI
 
-// MARK: - Focused Value Keys
+// MARK: - NavigationSelectionKey
 
 /// Key for the navigation selection binding.
 private struct NavigationSelectionKey: FocusedValueKey {
     typealias Value = Binding<NavigationSelection?>
 }
 
+// MARK: - ProjectDetailTabKey
+
 /// Key for the project detail tab binding.
 private struct ProjectDetailTabKey: FocusedValueKey {
     typealias Value = Binding<ProjectDetailTab>
 }
+
+// MARK: - GlobalSettingsTabKey
 
 /// Key for the global settings tab binding.
 private struct GlobalSettingsTabKey: FocusedValueKey {
     typealias Value = Binding<GlobalSettingsTab>
 }
 
+// MARK: - AddMCPServerActionKey
+
 /// Key for the add MCP server action.
 private struct AddMCPServerActionKey: FocusedValueKey {
     typealias Value = () -> Void
 }
+
+// MARK: - PasteMCPServersActionKey
 
 /// Key for the paste/import MCP servers action.
 private struct PasteMCPServersActionKey: FocusedValueKey {

--- a/Fig/Sources/App/FocusedValues.swift
+++ b/Fig/Sources/App/FocusedValues.swift
@@ -22,6 +22,11 @@ private struct AddMCPServerActionKey: FocusedValueKey {
     typealias Value = () -> Void
 }
 
+/// Key for the paste/import MCP servers action.
+private struct PasteMCPServersActionKey: FocusedValueKey {
+    typealias Value = () -> Void
+}
+
 // MARK: - FocusedValues Extension
 
 extension FocusedValues {
@@ -47,5 +52,11 @@ extension FocusedValues {
     var addMCPServerAction: (() -> Void)? {
         get { self[AddMCPServerActionKey.self] }
         set { self[AddMCPServerActionKey.self] = newValue }
+    }
+
+    /// Action to paste/import MCP servers from JSON.
+    var pasteMCPServersAction: (() -> Void)? {
+        get { self[PasteMCPServersActionKey.self] }
+        set { self[PasteMCPServersActionKey.self] = newValue }
     }
 }

--- a/Fig/Sources/Models/ConfigBundle.swift
+++ b/Fig/Sources/Models/ConfigBundle.swift
@@ -65,13 +65,13 @@ struct ConfigBundle: Codable, Equatable {
 
     /// Whether the bundle has any content.
     var isEmpty: Bool {
-        settings == nil && localSettings == nil && mcpServers == nil
+        self.settings == nil && self.localSettings == nil && self.mcpServers == nil
     }
 
     /// Whether the bundle contains potentially sensitive data.
     var containsSensitiveData: Bool {
         // Check local settings (usually contains sensitive data)
-        if localSettings != nil {
+        if self.localSettings != nil {
             return true
         }
 
@@ -151,7 +151,11 @@ enum ConfigBundleComponent: String, CaseIterable, Identifiable {
     case localSettings
     case mcpServers
 
-    var id: String { rawValue }
+    // MARK: Internal
+
+    var id: String {
+        rawValue
+    }
 
     var displayName: String {
         switch self {
@@ -189,17 +193,16 @@ enum ConfigBundleComponent: String, CaseIterable, Identifiable {
 
 /// Represents a conflict found during import.
 struct ImportConflict: Identifiable {
-    let id = UUID()
-    let component: ConfigBundleComponent
-    let description: String
-    var resolution: ImportResolution = .merge
-
     enum ImportResolution: String, CaseIterable, Identifiable {
-        case merge    // Combine with existing (for arrays/dicts)
-        case replace  // Replace existing completely
-        case skip     // Keep existing, skip import
+        case merge // Combine with existing (for arrays/dicts)
+        case replace // Replace existing completely
+        case skip // Keep existing, skip import
 
-        var id: String { rawValue }
+        // MARK: Internal
+
+        var id: String {
+            rawValue
+        }
 
         var displayName: String {
             switch self {
@@ -209,6 +212,11 @@ struct ImportConflict: Identifiable {
             }
         }
     }
+
+    let id = UUID()
+    let component: ConfigBundleComponent
+    let description: String
+    var resolution: ImportResolution = .merge
 }
 
 // MARK: - ImportResult

--- a/Fig/Sources/Models/Finding.swift
+++ b/Fig/Sources/Models/Finding.swift
@@ -91,6 +91,23 @@ enum AutoFix: Sendable, Equatable {
 
 /// A single finding from a health check.
 struct Finding: Identifiable, Sendable {
+    // MARK: Lifecycle
+
+    init(
+        severity: Severity,
+        title: String,
+        description: String,
+        autoFix: AutoFix? = nil
+    ) {
+        self.id = UUID()
+        self.severity = severity
+        self.title = title
+        self.description = description
+        self.autoFix = autoFix
+    }
+
+    // MARK: Internal
+
     /// Unique identifier for this finding.
     let id: UUID
 
@@ -105,19 +122,6 @@ struct Finding: Identifiable, Sendable {
 
     /// Optional auto-fix action for this finding.
     let autoFix: AutoFix?
-
-    init(
-        severity: Severity,
-        title: String,
-        description: String,
-        autoFix: AutoFix? = nil
-    ) {
-        self.id = UUID()
-        self.severity = severity
-        self.title = title
-        self.description = description
-        self.autoFix = autoFix
-    }
 }
 
 // MARK: - HealthCheckContext

--- a/Fig/Sources/Models/ProjectGroup.swift
+++ b/Fig/Sources/Models/ProjectGroup.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+// MARK: - ProjectGroup
+
+/// A group of projects sharing the same parent directory.
+///
+/// Used to visually organize projects in the sidebar when grouping
+/// by parent directory is enabled. This reduces noise from git worktrees
+/// and similar directory structures where many projects share a common parent.
+struct ProjectGroup: Identifiable, Sendable {
+    /// The full path to the parent directory.
+    let parentPath: String
+
+    /// Display-friendly name (abbreviated with ~).
+    let displayName: String
+
+    /// Projects in this group, sorted by name.
+    let projects: [ProjectEntry]
+
+    var id: String { self.parentPath }
+}

--- a/Fig/Sources/Models/SettingsEditorTypes.swift
+++ b/Fig/Sources/Models/SettingsEditorTypes.swift
@@ -5,41 +5,44 @@ import SwiftUI
 
 /// A permission rule with editing metadata.
 struct EditablePermissionRule: Identifiable, Equatable, Hashable {
-    let id: UUID
-    var rule: String
-    var type: PermissionType
+    // MARK: Lifecycle
 
     init(id: UUID = UUID(), rule: String, type: PermissionType) {
         self.id = id
         self.rule = rule
         self.type = type
     }
+
+    // MARK: Internal
+
+    let id: UUID
+    var rule: String
+    var type: PermissionType
 }
 
 // MARK: - EditableEnvironmentVariable
 
 /// An environment variable with editing metadata.
 struct EditableEnvironmentVariable: Identifiable, Equatable, Hashable {
-    let id: UUID
-    var key: String
-    var value: String
+    // MARK: Lifecycle
 
     init(id: UUID = UUID(), key: String, value: String) {
         self.id = id
         self.key = key
         self.value = value
     }
+
+    // MARK: Internal
+
+    let id: UUID
+    var key: String
+    var value: String
 }
 
 // MARK: - KnownEnvironmentVariable
 
 /// Known Claude Code environment variables with descriptions.
 struct KnownEnvironmentVariable: Identifiable {
-    let id: String
-    let name: String
-    let description: String
-    let defaultValue: String?
-
     static let allVariables: [KnownEnvironmentVariable] = [
         KnownEnvironmentVariable(
             id: "CLAUDE_CODE_MAX_OUTPUT_TOKENS",
@@ -100,11 +103,16 @@ struct KnownEnvironmentVariable: Identifiable {
             name: "ANTHROPIC_DEFAULT_HAIKU_MODEL",
             description: "Default Haiku model to use",
             defaultValue: nil
-        )
+        ),
     ]
 
+    let id: String
+    let name: String
+    let description: String
+    let defaultValue: String?
+
     static func description(for key: String) -> String? {
-        allVariables.first { $0.name == key }?.description
+        self.allVariables.first { $0.name == key }?.description
     }
 }
 
@@ -112,11 +120,6 @@ struct KnownEnvironmentVariable: Identifiable {
 
 /// Quick-add presets for common permission patterns.
 struct PermissionPreset: Identifiable {
-    let id: String
-    let name: String
-    let description: String
-    let rules: [(rule: String, type: PermissionType)]
-
     static let allPresets: [PermissionPreset] = [
         PermissionPreset(
             id: "protect-env",
@@ -124,7 +127,7 @@ struct PermissionPreset: Identifiable {
             description: "Prevent reading environment files",
             rules: [
                 ("Read(.env)", .deny),
-                ("Read(.env.*)", .deny)
+                ("Read(.env.*)", .deny),
             ]
         ),
         PermissionPreset(
@@ -132,7 +135,7 @@ struct PermissionPreset: Identifiable {
             name: "Allow npm scripts",
             description: "Allow running npm scripts",
             rules: [
-                ("Bash(npm run *)", .allow)
+                ("Bash(npm run *)", .allow),
             ]
         ),
         PermissionPreset(
@@ -140,7 +143,7 @@ struct PermissionPreset: Identifiable {
             name: "Allow git operations",
             description: "Allow running git commands",
             rules: [
-                ("Bash(git *)", .allow)
+                ("Bash(git *)", .allow),
             ]
         ),
         PermissionPreset(
@@ -149,7 +152,7 @@ struct PermissionPreset: Identifiable {
             description: "Deny all write and edit operations",
             rules: [
                 ("Write", .deny),
-                ("Edit", .deny)
+                ("Edit", .deny),
             ]
         ),
         PermissionPreset(
@@ -157,7 +160,7 @@ struct PermissionPreset: Identifiable {
             name: "Allow reading source",
             description: "Allow reading all files in src directory",
             rules: [
-                ("Read(src/**)", .allow)
+                ("Read(src/**)", .allow),
             ]
         ),
         PermissionPreset(
@@ -165,10 +168,15 @@ struct PermissionPreset: Identifiable {
             name: "Block curl commands",
             description: "Prevent curl network requests",
             rules: [
-                ("Bash(curl *)", .deny)
+                ("Bash(curl *)", .deny),
             ]
-        )
+        ),
     ]
+
+    let id: String
+    let name: String
+    let description: String
+    let rules: [(rule: String, type: PermissionType)]
 }
 
 // MARK: - ToolType
@@ -185,7 +193,11 @@ enum ToolType: String, CaseIterable, Identifiable {
     case notebook = "Notebook"
     case custom = "Custom"
 
-    var id: String { rawValue }
+    // MARK: Internal
+
+    var id: String {
+        rawValue
+    }
 
     var placeholder: String {
         switch self {
@@ -223,7 +235,16 @@ enum EditingTarget: String, CaseIterable, Identifiable {
     case projectShared
     case projectLocal
 
-    var id: String { rawValue }
+    // MARK: Internal
+
+    /// Targets available when editing project settings.
+    static var projectTargets: [EditingTarget] {
+        [.projectShared, .projectLocal]
+    }
+
+    var id: String {
+        rawValue
+    }
 
     var label: String {
         switch self {
@@ -257,21 +278,13 @@ enum EditingTarget: String, CaseIterable, Identifiable {
             .projectLocal
         }
     }
-
-    /// Targets available when editing project settings.
-    static var projectTargets: [EditingTarget] {
-        [.projectShared, .projectLocal]
-    }
 }
 
 // MARK: - EditableHookDefinition
 
 /// A hook definition with editing metadata.
 struct EditableHookDefinition: Identifiable, Equatable, Hashable {
-    let id: UUID
-    var type: String
-    var command: String
-    var additionalProperties: [String: AnyCodable]?
+    // MARK: Lifecycle
 
     init(id: UUID = UUID(), type: String = "command", command: String = "") {
         self.id = id
@@ -287,11 +300,18 @@ struct EditableHookDefinition: Identifiable, Equatable, Hashable {
         self.additionalProperties = definition.additionalProperties
     }
 
+    // MARK: Internal
+
+    let id: UUID
+    var type: String
+    var command: String
+    var additionalProperties: [String: AnyCodable]?
+
     func toHookDefinition() -> HookDefinition {
         HookDefinition(
-            type: type,
-            command: command.isEmpty ? nil : command,
-            additionalProperties: additionalProperties
+            type: self.type,
+            command: self.command.isEmpty ? nil : self.command,
+            additionalProperties: self.additionalProperties
         )
     }
 }
@@ -300,10 +320,7 @@ struct EditableHookDefinition: Identifiable, Equatable, Hashable {
 
 /// A hook group with editing metadata.
 struct EditableHookGroup: Identifiable, Equatable, Hashable {
-    let id: UUID
-    var matcher: String
-    var hooks: [EditableHookDefinition]
-    var additionalProperties: [String: AnyCodable]?
+    // MARK: Lifecycle
 
     init(id: UUID = UUID(), matcher: String = "", hooks: [EditableHookDefinition] = []) {
         self.id = id
@@ -319,11 +336,18 @@ struct EditableHookGroup: Identifiable, Equatable, Hashable {
         self.additionalProperties = group.additionalProperties
     }
 
+    // MARK: Internal
+
+    let id: UUID
+    var matcher: String
+    var hooks: [EditableHookDefinition]
+    var additionalProperties: [String: AnyCodable]?
+
     func toHookGroup() -> HookGroup {
         HookGroup(
-            matcher: matcher.isEmpty ? nil : matcher,
-            hooks: hooks.isEmpty ? nil : hooks.map { $0.toHookDefinition() },
-            additionalProperties: additionalProperties
+            matcher: self.matcher.isEmpty ? nil : self.matcher,
+            hooks: self.hooks.isEmpty ? nil : self.hooks.map { $0.toHookDefinition() },
+            additionalProperties: self.additionalProperties
         )
     }
 }
@@ -339,7 +363,9 @@ enum HookEvent: String, CaseIterable, Identifiable {
 
     // MARK: Internal
 
-    var id: String { rawValue }
+    var id: String {
+        rawValue
+    }
 
     var displayName: String {
         switch self {
@@ -379,8 +405,10 @@ enum HookEvent: String, CaseIterable, Identifiable {
 
     var supportsMatcher: Bool {
         switch self {
-        case .preToolUse, .postToolUse: true
-        case .notification, .stop: false
+        case .preToolUse,
+             .postToolUse: true
+        case .notification,
+             .stop: false
         }
     }
 
@@ -442,13 +470,6 @@ extension HookVariable {
 
 /// Quick-add templates for common hook configurations.
 struct HookTemplate: Identifiable {
-    let id: String
-    let name: String
-    let description: String
-    let event: HookEvent
-    let matcher: String?
-    let commands: [String]
-
     static let allTemplates: [HookTemplate] = [
         HookTemplate(
             id: "format-python",
@@ -501,6 +522,13 @@ struct HookTemplate: Identifiable {
             commands: ["swift-format format -i $CLAUDE_FILE_PATH"]
         ),
     ]
+
+    let id: String
+    let name: String
+    let description: String
+    let event: HookEvent
+    let matcher: String?
+    let commands: [String]
 }
 
 // MARK: - ConflictResolution

--- a/Fig/Sources/Services/ConfigFileManager.swift
+++ b/Fig/Sources/Services/ConfigFileManager.swift
@@ -216,7 +216,7 @@ actor ConfigFileManager {
 
     /// Writes the global legacy config to ~/.claude.json.
     func writeGlobalConfig(_ config: LegacyConfig) async throws {
-        try await write(config, to: globalConfigURL)
+        try await self.write(config, to: self.globalConfigURL)
     }
 
     // MARK: - File Watching

--- a/Fig/Sources/Services/MCPSharingService.swift
+++ b/Fig/Sources/Services/MCPSharingService.swift
@@ -1,0 +1,423 @@
+import AppKit
+import Foundation
+import OSLog
+
+// MARK: - MCPSharingError
+
+/// Errors that can occur during MCP sharing operations.
+enum MCPSharingError: Error, LocalizedError {
+    case invalidJSON(String)
+    case noServersFound
+    case serializationFailed(underlying: Error)
+    case importFailed(underlying: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case let .invalidJSON(detail):
+            "Invalid JSON: \(detail)"
+        case .noServersFound:
+            "No MCP servers found in the provided JSON."
+        case let .serializationFailed(error):
+            "Serialization failed: \(error.localizedDescription)"
+        case let .importFailed(error):
+            "Import failed: \(error.localizedDescription)"
+        }
+    }
+}
+
+// MARK: - BulkImportResult
+
+/// Result of a bulk import operation.
+struct BulkImportResult: Sendable, Equatable {
+    let imported: [String]
+    let skipped: [String]
+    let renamed: [String: String]
+    let errors: [String]
+
+    var totalImported: Int { imported.count + renamed.count }
+
+    var summary: String {
+        var parts: [String] = []
+        if !imported.isEmpty {
+            parts.append("\(imported.count) imported")
+        }
+        if !renamed.isEmpty {
+            parts.append("\(renamed.count) renamed")
+        }
+        if !skipped.isEmpty {
+            parts.append("\(skipped.count) skipped")
+        }
+        if !errors.isEmpty {
+            parts.append("\(errors.count) errors")
+        }
+        return parts.joined(separator: ", ")
+    }
+}
+
+// MARK: - MCPSharingService
+
+/// Service for sharing MCP server configurations via clipboard and bulk import/export.
+actor MCPSharingService {
+    // MARK: Internal
+
+    static let shared = MCPSharingService()
+
+    // MARK: - Serialization
+
+    /// Serializes servers to MCPConfig JSON format matching `.mcp.json`.
+    ///
+    /// When `redactSensitive` is true, replaces sensitive env var values with
+    /// `<YOUR_KEY_NAME>` placeholders and sensitive header values with `<YOUR_HEADER_NAME>`.
+    nonisolated func serializeToJSON(
+        servers: [String: MCPServer],
+        redactSensitive: Bool = false
+    ) throws -> String {
+        let finalServers = redactSensitive ? redactServers(servers) : servers
+        let config = MCPConfig(mcpServers: finalServers)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        do {
+            let data = try encoder.encode(config)
+            guard let json = String(data: data, encoding: .utf8) else {
+                throw MCPSharingError.serializationFailed(
+                    underlying: NSError(
+                        domain: "MCPSharingService",
+                        code: 0,
+                        userInfo: [NSLocalizedDescriptionKey: "Failed to convert data to UTF-8 string"]
+                    )
+                )
+            }
+            return json
+        } catch let error as MCPSharingError {
+            throw error
+        } catch {
+            throw MCPSharingError.serializationFailed(underlying: error)
+        }
+    }
+
+    // MARK: - Parsing
+
+    /// Parses JSON text into a dictionary of MCP servers.
+    ///
+    /// Accepts multiple formats:
+    /// - MCPConfig: `{"mcpServers": {"name": {...}, ...}}`
+    /// - Flat dict: `{"name": {"command": "..."}, "name2": {...}}`
+    /// - Single named: `{"name": {"command": "..."}}`
+    /// - Single unnamed: `{"command": "...", "args": [...]}`
+    func parseServersFromJSON(_ json: String) throws -> [String: MCPServer] {
+        guard let data = json.data(using: .utf8) else {
+            throw MCPSharingError.invalidJSON("Input is not valid UTF-8")
+        }
+
+        // Try MCPConfig format first
+        if let config = try? JSONDecoder().decode(MCPConfig.self, from: data),
+           let servers = config.mcpServers, !servers.isEmpty
+        {
+            return servers
+        }
+
+        // Try flat dictionary of servers
+        if let dict = try? JSONDecoder().decode([String: MCPServer].self, from: data) {
+            // Filter to entries that look like actual servers (have command or url)
+            let validServers = dict.filter { $0.value.command != nil || $0.value.url != nil }
+            if !validServers.isEmpty {
+                return validServers
+            }
+        }
+
+        // Try single unnamed server
+        if let server = try? JSONDecoder().decode(MCPServer.self, from: data),
+           server.command != nil || server.url != nil
+        {
+            return ["server": server]
+        }
+
+        throw MCPSharingError.noServersFound
+    }
+
+    // MARK: - Sensitive Data Detection
+
+    /// Detects sensitive environment variables and headers across multiple servers.
+    func detectSensitiveData(servers: [String: MCPServer]) -> [SensitiveEnvWarning] {
+        var warnings: [SensitiveEnvWarning] = []
+
+        for (serverName, server) in servers.sorted(by: { $0.key < $1.key }) {
+            // Check env vars
+            if let env = server.env {
+                for key in env.keys.sorted() {
+                    if isSensitiveKey(key) {
+                        warnings.append(SensitiveEnvWarning(
+                            key: "\(serverName).\(key)",
+                            reason: sensitiveReason(for: key)
+                        ))
+                    }
+                }
+            }
+
+            // Check headers
+            if let headers = server.headers {
+                for key in headers.keys.sorted() {
+                    if isSensitiveKey(key) {
+                        warnings.append(SensitiveEnvWarning(
+                            key: "\(serverName).\(key)",
+                            reason: sensitiveReason(for: key)
+                        ))
+                    }
+                }
+            }
+        }
+
+        return warnings
+    }
+
+    /// Checks if any server has sensitive data.
+    func containsSensitiveData(servers: [String: MCPServer]) -> Bool {
+        !detectSensitiveData(servers: servers).isEmpty
+    }
+
+    // MARK: - Clipboard Operations
+
+    /// Writes MCP config JSON to the system clipboard.
+    @MainActor
+    func writeToClipboard(
+        servers: [String: MCPServer],
+        redactSensitive: Bool = false
+    ) throws {
+        let json = try serializeToJSON(servers: servers, redactSensitive: redactSensitive)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(json, forType: .string)
+    }
+
+    /// Reads text content from the system clipboard.
+    @MainActor
+    func readFromClipboard() -> String? {
+        NSPasteboard.general.string(forType: .string)
+    }
+
+    // MARK: - Bulk Import
+
+    /// Imports multiple servers into a destination, handling conflicts by strategy.
+    func importServers(
+        _ servers: [String: MCPServer],
+        to destination: CopyDestination,
+        strategy: ConflictStrategy,
+        configManager: ConfigFileManager = .shared
+    ) async throws -> BulkImportResult {
+        var imported: [String] = []
+        var skipped: [String] = []
+        var renamed: [String: String] = [:]
+        var errors: [String] = []
+
+        let existingServers = await getExistingServers(
+            at: destination,
+            configManager: configManager
+        )
+
+        // Build a set of all names (existing + already imported) to avoid collisions
+        var allNames = Set(existingServers.keys)
+
+        for (name, server) in servers.sorted(by: { $0.key < $1.key }) {
+            let hasConflict = allNames.contains(name)
+
+            if hasConflict {
+                switch strategy {
+                case .skip, .prompt:
+                    skipped.append(name)
+                    continue
+
+                case .overwrite:
+                    do {
+                        try await writeServer(
+                            name: name,
+                            server: server,
+                            to: destination,
+                            configManager: configManager
+                        )
+                        imported.append(name)
+                    } catch {
+                        errors.append("\(name): \(error.localizedDescription)")
+                    }
+
+                case .rename:
+                    let newName = generateUniqueName(baseName: name, existingNames: allNames)
+                    do {
+                        try await writeServer(
+                            name: newName,
+                            server: server,
+                            to: destination,
+                            configManager: configManager
+                        )
+                        renamed[name] = newName
+                        allNames.insert(newName)
+                    } catch {
+                        errors.append("\(name): \(error.localizedDescription)")
+                    }
+                }
+            } else {
+                do {
+                    try await writeServer(
+                        name: name,
+                        server: server,
+                        to: destination,
+                        configManager: configManager
+                    )
+                    imported.append(name)
+                    allNames.insert(name)
+                } catch {
+                    errors.append("\(name): \(error.localizedDescription)")
+                }
+            }
+        }
+
+        Log.general.info(
+            "Bulk import: \(imported.count) imported, \(renamed.count) renamed, \(skipped.count) skipped, \(errors.count) errors"
+        )
+
+        return BulkImportResult(
+            imported: imported,
+            skipped: skipped,
+            renamed: renamed,
+            errors: errors
+        )
+    }
+
+    // MARK: Private
+
+    private init() {}
+
+    // MARK: - Sensitive Data Helpers
+
+    private static let sensitivePatterns = [
+        "token", "key", "secret", "password", "passwd",
+        "credential", "auth", "api",
+    ]
+
+    private nonisolated func isSensitiveKey(_ key: String) -> Bool {
+        let lowerKey = key.lowercased()
+        return Self.sensitivePatterns.contains { lowerKey.contains($0) }
+    }
+
+    private func sensitiveReason(for key: String) -> String {
+        let lowerKey = key.lowercased()
+        if lowerKey.contains("token") {
+            return "May contain authentication token"
+        } else if lowerKey.contains("key") || lowerKey.contains("api") {
+            return "May contain API key"
+        } else if lowerKey.contains("secret") {
+            return "May contain secret value"
+        } else if lowerKey.contains("password") || lowerKey.contains("passwd") {
+            return "May contain password"
+        } else if lowerKey.contains("credential") || lowerKey.contains("auth") {
+            return "May contain credentials"
+        }
+        return "May contain sensitive data"
+    }
+
+    // MARK: - Redaction
+
+    private nonisolated func redactServers(_ servers: [String: MCPServer]) -> [String: MCPServer] {
+        var result: [String: MCPServer] = [:]
+        for (name, server) in servers {
+            result[name] = redactServer(server)
+        }
+        return result
+    }
+
+    private nonisolated func redactServer(_ server: MCPServer) -> MCPServer {
+        var redacted = server
+
+        // Redact sensitive env vars
+        if let env = server.env {
+            var redactedEnv: [String: String] = [:]
+            for (key, value) in env {
+                if isSensitiveKey(key) {
+                    redactedEnv[key] = "<YOUR_\(key.uppercased())>"
+                } else {
+                    redactedEnv[key] = value
+                }
+            }
+            redacted.env = redactedEnv
+        }
+
+        // Redact sensitive headers
+        if let headers = server.headers {
+            var redactedHeaders: [String: String] = [:]
+            for (key, value) in headers {
+                if isSensitiveKey(key) {
+                    redactedHeaders[key] = "<YOUR_\(key.uppercased())>"
+                } else {
+                    redactedHeaders[key] = value
+                }
+            }
+            redacted.headers = redactedHeaders
+        }
+
+        return redacted
+    }
+
+    // MARK: - Name Generation
+
+    private func generateUniqueName(baseName: String, existingNames: Set<String>) -> String {
+        var candidate = "\(baseName)-copy"
+        var counter = 2
+
+        while existingNames.contains(candidate) {
+            candidate = "\(baseName)-copy-\(counter)"
+            counter += 1
+        }
+
+        return candidate
+    }
+
+    // MARK: - Destination Helpers
+
+    private func getExistingServers(
+        at destination: CopyDestination,
+        configManager: ConfigFileManager
+    ) async -> [String: MCPServer] {
+        do {
+            switch destination {
+            case .global:
+                let config = try await configManager.readGlobalConfig()
+                return config?.mcpServers ?? [:]
+
+            case let .project(path, _):
+                let url = URL(fileURLWithPath: path)
+                let mcpConfig = try await configManager.readMCPConfig(for: url)
+                return mcpConfig?.mcpServers ?? [:]
+            }
+        } catch {
+            Log.general.error("Failed to read servers at destination: \(error)")
+            return [:]
+        }
+    }
+
+    private func writeServer(
+        name: String,
+        server: MCPServer,
+        to destination: CopyDestination,
+        configManager: ConfigFileManager
+    ) async throws {
+        switch destination {
+        case .global:
+            var config = try await configManager.readGlobalConfig() ?? LegacyConfig()
+            if config.mcpServers == nil {
+                config.mcpServers = [:]
+            }
+            config.mcpServers?[name] = server
+            try await configManager.writeGlobalConfig(config)
+
+        case let .project(path, _):
+            let url = URL(fileURLWithPath: path)
+            var mcpConfig = try await configManager.readMCPConfig(for: url)
+                ?? MCPConfig(mcpServers: [:])
+            if mcpConfig.mcpServers == nil {
+                mcpConfig.mcpServers = [:]
+            }
+            mcpConfig.mcpServers?[name] = server
+            try await configManager.writeMCPConfig(mcpConfig, for: url)
+        }
+    }
+}

--- a/Fig/Sources/Services/PermissionRuleCopyService.swift
+++ b/Fig/Sources/Services/PermissionRuleCopyService.swift
@@ -59,7 +59,7 @@ actor PermissionRuleCopyService {
 
         settings.permissions = permissions
 
-        try await writeSettings(
+        try await self.writeSettings(
             settings,
             for: destination,
             projectPath: projectPath,
@@ -113,7 +113,7 @@ actor PermissionRuleCopyService {
             settings.permissions = permissions
         }
 
-        try await writeSettings(
+        try await self.writeSettings(
             settings,
             for: source,
             projectPath: projectPath,
@@ -136,12 +136,11 @@ actor PermissionRuleCopyService {
             projectPath: projectPath,
             configManager: configManager
         )
-        let existingRules: [String]
-        switch type {
+        let existingRules: [String] = switch type {
         case .allow:
-            existingRules = settings?.permissions?.allow ?? []
+            settings?.permissions?.allow ?? []
         case .deny:
-            existingRules = settings?.permissions?.deny ?? []
+            settings?.permissions?.deny ?? []
         }
         return existingRules.contains(rule)
     }

--- a/Fig/Sources/ViewModels/MCPCopyViewModel.swift
+++ b/Fig/Sources/ViewModels/MCPCopyViewModel.swift
@@ -71,17 +71,23 @@ final class MCPCopyViewModel {
 
     /// Whether the copy can proceed.
     var canCopy: Bool {
-        guard let destination = selectedDestination else { return false }
+        guard let destination = selectedDestination else {
+            return false
+        }
         // Can't copy to same location
-        if let source = sourceDestination, source == destination { return false }
+        if let source = sourceDestination, source == destination {
+            return false
+        }
         // Must acknowledge sensitive data if present
-        if !sensitiveWarnings.isEmpty && !acknowledgedSensitiveData { return false }
-        return !isCopying
+        if !self.sensitiveWarnings.isEmpty, !self.acknowledgedSensitiveData {
+            return false
+        }
+        return !self.isCopying
     }
 
     /// Loads available destinations from projects.
     func loadDestinations(projects: [ProjectEntry]) {
-        isLoadingDestinations = true
+        self.isLoadingDestinations = true
 
         var destinations: [CopyDestination] = [.global]
 
@@ -100,53 +106,53 @@ final class MCPCopyViewModel {
             destinations = destinations.filter { $0 != source }
         }
 
-        availableDestinations = destinations
-        isLoadingDestinations = false
+        self.availableDestinations = destinations
+        self.isLoadingDestinations = false
     }
 
     /// Checks for conflicts at the selected destination.
     func checkForConflict() async {
         guard let destination = selectedDestination else {
-            conflict = nil
+            self.conflict = nil
             return
         }
 
-        conflict = await MCPServerCopyService.shared.checkConflict(
-            serverName: serverName,
-            server: server,
+        self.conflict = await MCPServerCopyService.shared.checkConflict(
+            serverName: self.serverName,
+            server: self.server,
             destination: destination,
-            configManager: configManager
+            configManager: self.configManager
         )
 
         // Pre-fill renamed name if conflict exists
-        if conflict != nil {
-            renamedServerName = serverName + "-copy"
+        if self.conflict != nil {
+            self.renamedServerName = self.serverName + "-copy"
         }
     }
 
     /// Performs the copy with the specified resolution.
     func performCopy(resolution: CopyConflict.ConflictResolution? = nil) async {
-        guard let destination = selectedDestination else { return }
+        guard let destination = selectedDestination else {
+            return
+        }
 
-        isCopying = true
-        errorMessage = nil
-        copyResult = nil
+        self.isCopying = true
+        self.errorMessage = nil
+        self.copyResult = nil
 
         do {
-            let result: CopyResult
-
-            if let conflict, let resolution {
-                result = try await MCPServerCopyService.shared.copyServerWithResolution(
-                    name: serverName,
-                    server: server,
+            let result: CopyResult = if let conflict, let resolution {
+                try await MCPServerCopyService.shared.copyServerWithResolution(
+                    name: self.serverName,
+                    server: self.server,
                     to: destination,
                     resolution: resolution,
-                    configManager: configManager
+                    configManager: self.configManager
                 )
             } else if conflict != nil {
                 // Conflict exists but no resolution provided - skip
-                result = CopyResult(
-                    serverName: serverName,
+                CopyResult(
+                    serverName: self.serverName,
                     destination: destination,
                     success: false,
                     message: "Conflict not resolved",
@@ -155,16 +161,16 @@ final class MCPCopyViewModel {
                 )
             } else {
                 // No conflict, direct copy
-                result = try await MCPServerCopyService.shared.copyServer(
-                    name: serverName,
-                    server: server,
+                try await MCPServerCopyService.shared.copyServer(
+                    name: self.serverName,
+                    server: self.server,
                     to: destination,
                     strategy: .overwrite,
-                    configManager: configManager
+                    configManager: self.configManager
                 )
             }
 
-            copyResult = result
+            self.copyResult = result
 
             if result.success {
                 // Show success notification
@@ -174,34 +180,34 @@ final class MCPCopyViewModel {
                 )
             }
         } catch {
-            errorMessage = error.localizedDescription
+            self.errorMessage = error.localizedDescription
             NotificationManager.shared.showError(
                 "Copy failed",
                 message: error.localizedDescription
             )
         }
 
-        isCopying = false
+        self.isCopying = false
     }
 
     /// Copies with overwrite resolution.
     func copyWithOverwrite() async {
-        await performCopy(resolution: .overwrite)
+        await self.performCopy(resolution: .overwrite)
     }
 
     /// Copies with rename resolution.
     func copyWithRename() async {
-        let newName = renamedServerName.trimmingCharacters(in: .whitespaces)
+        let newName = self.renamedServerName.trimmingCharacters(in: .whitespaces)
         guard !newName.isEmpty else {
-            errorMessage = "Please enter a new name"
+            self.errorMessage = "Please enter a new name"
             return
         }
-        await performCopy(resolution: .rename(newName))
+        await self.performCopy(resolution: .rename(newName))
     }
 
     /// Skips the copy due to conflict.
     func skipCopy() async {
-        await performCopy(resolution: .skip)
+        await self.performCopy(resolution: .skip)
     }
 
     // MARK: Private

--- a/Fig/Sources/ViewModels/MCPPasteViewModel.swift
+++ b/Fig/Sources/ViewModels/MCPPasteViewModel.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+// MARK: - MCPPasteViewModel
+
+/// View model for the paste/import MCP servers flow.
+@MainActor
+@Observable
+final class MCPPasteViewModel {
+    // MARK: Lifecycle
+
+    init(
+        currentProject: CopyDestination? = nil,
+        sharingService: MCPSharingService = .shared
+    ) {
+        self.currentProject = currentProject
+        self.sharingService = sharingService
+        self.selectedDestination = currentProject
+    }
+
+    // MARK: Internal
+
+    /// The JSON text entered by the user.
+    var jsonText: String = "" {
+        didSet {
+            parseJSON()
+        }
+    }
+
+    /// The selected destination for import.
+    var selectedDestination: CopyDestination?
+
+    /// The conflict strategy to use.
+    var conflictStrategy: ConflictStrategy = .rename
+
+    /// Whether import is in progress.
+    private(set) var isImporting = false
+
+    /// Parsed servers from the JSON text.
+    private(set) var parsedServers: [String: MCPServer]?
+
+    /// Error from parsing.
+    private(set) var parseError: String?
+
+    /// The import result after a successful import.
+    private(set) var importResult: BulkImportResult?
+
+    /// Error from import.
+    private(set) var errorMessage: String?
+
+    /// Available destinations for import.
+    private(set) var availableDestinations: [CopyDestination] = []
+
+    /// Number of parsed servers.
+    var serverCount: Int { parsedServers?.count ?? 0 }
+
+    /// Sorted server names from parsed JSON.
+    var serverNames: [String] { parsedServers?.keys.sorted() ?? [] }
+
+    /// Whether the import can proceed.
+    var canImport: Bool {
+        guard let servers = parsedServers, !servers.isEmpty else { return false }
+        guard selectedDestination != nil else { return false }
+        guard !isImporting else { return false }
+        return true
+    }
+
+    /// Whether the import completed successfully.
+    var importSucceeded: Bool {
+        importResult?.totalImported ?? 0 > 0
+    }
+
+    /// Loads available destinations from projects.
+    func loadDestinations(projects: [ProjectEntry]) {
+        var destinations: [CopyDestination] = [.global]
+
+        for project in projects {
+            if let path = project.path, let name = project.name {
+                destinations.append(.project(path: path, name: name))
+            }
+        }
+
+        availableDestinations = destinations
+    }
+
+    /// Reads JSON from the system clipboard and sets it as the input text.
+    func loadFromClipboard() async {
+        if let clipboardText = sharingService.readFromClipboard() {
+            jsonText = clipboardText
+        }
+    }
+
+    /// Performs the import operation.
+    func performImport() async {
+        guard let servers = parsedServers, !servers.isEmpty,
+              let destination = selectedDestination
+        else { return }
+
+        isImporting = true
+        errorMessage = nil
+        importResult = nil
+
+        do {
+            let result = try await sharingService.importServers(
+                servers,
+                to: destination,
+                strategy: conflictStrategy
+            )
+
+            importResult = result
+
+            if result.totalImported > 0 {
+                NotificationManager.shared.showSuccess(
+                    "Import successful",
+                    message: "\(result.totalImported) server(s) imported"
+                )
+            } else if !result.skipped.isEmpty {
+                NotificationManager.shared.showInfo(
+                    "Import skipped",
+                    message: "All servers were skipped due to conflicts"
+                )
+            }
+
+        } catch {
+            errorMessage = error.localizedDescription
+            NotificationManager.shared.showError(
+                "Import failed",
+                message: error.localizedDescription
+            )
+        }
+
+        isImporting = false
+    }
+
+    // MARK: Private
+
+    /// The current project destination (for pre-selection).
+    private let currentProject: CopyDestination?
+
+    private let sharingService: MCPSharingService
+
+    private func parseJSON() {
+        parsedServers = nil
+        parseError = nil
+
+        let trimmed = jsonText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        Task {
+            do {
+                parsedServers = try await sharingService.parseServersFromJSON(trimmed)
+                parseError = nil
+            } catch {
+                parsedServers = nil
+                parseError = error.localizedDescription
+            }
+        }
+    }
+}

--- a/Fig/Sources/ViewModels/OnboardingViewModel.swift
+++ b/Fig/Sources/ViewModels/OnboardingViewModel.swift
@@ -32,6 +32,9 @@ final class OnboardingViewModel {
         case completion = 4
     }
 
+    /// Total number of tour pages.
+    static let tourPageCount = 4
+
     /// The current onboarding step.
     private(set) var currentStep: Step = .welcome
 
@@ -46,9 +49,6 @@ final class OnboardingViewModel {
 
     /// Current page index within the feature tour (0-based).
     var currentTourPage: Int = 0
-
-    /// Total number of tour pages.
-    static let tourPageCount = 4
 
     /// Whether the current step is the first step.
     var isFirstStep: Bool {

--- a/Fig/Sources/ViewModels/ProjectDetailViewModel.swift
+++ b/Fig/Sources/ViewModels/ProjectDetailViewModel.swift
@@ -363,20 +363,27 @@ final class ProjectDetailViewModel {
             switch source {
             case .projectShared:
                 // Delete from .mcp.json
-                guard var config = mcpConfig else { return }
+                guard var config = mcpConfig else {
+                    return
+                }
                 config.mcpServers?.removeValue(forKey: name)
-                try await configManager.writeMCPConfig(config, for: projectURL)
-                mcpConfig = config
+                try await self.configManager.writeMCPConfig(config, for: self.projectURL)
+                self.mcpConfig = config
                 NotificationManager.shared.showSuccess("Server deleted", message: "'\(name)' removed from project")
 
             case .global:
                 // Delete from ~/.claude.json
-                guard var globalConfig = try await configManager.readGlobalConfig() else { return }
+                guard var globalConfig = try await configManager.readGlobalConfig() else {
+                    return
+                }
                 globalConfig.mcpServers?.removeValue(forKey: name)
-                try await configManager.writeGlobalConfig(globalConfig)
+                try await self.configManager.writeGlobalConfig(globalConfig)
                 // Also update projectEntry if it exists
-                projectEntry = globalConfig.project(at: projectPath)
-                NotificationManager.shared.showSuccess("Server deleted", message: "'\(name)' removed from global config")
+                self.projectEntry = globalConfig.project(at: self.projectPath)
+                NotificationManager.shared.showSuccess(
+                    "Server deleted",
+                    message: "'\(name)' removed from global config"
+                )
 
             case .projectLocal:
                 // Local settings don't typically have MCP servers, but handle gracefully
@@ -405,7 +412,9 @@ final class ProjectDetailViewModel {
         ]
 
         for (settings, source) in sources {
-            guard let env = settings?.env else { continue }
+            guard let env = settings?.env else {
+                continue
+            }
             for (key, value) in env {
                 allValues[key, default: []].append((value, source))
             }

--- a/Fig/Sources/Views/AttributionEditorViews.swift
+++ b/Fig/Sources/Views/AttributionEditorViews.swift
@@ -12,9 +12,9 @@ struct AttributionSettingsEditorView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
                 // Target selector
-                if !viewModel.isGlobalMode {
+                if !self.viewModel.isGlobalMode {
                     HStack {
-                        EditingTargetPicker(selection: $viewModel.editingTarget)
+                        EditingTargetPicker(selection: self.$viewModel.editingTarget)
                         Spacer()
                     }
                 }
@@ -22,7 +22,7 @@ struct AttributionSettingsEditorView: View {
                 // Attribution settings
                 GroupBox("Attribution") {
                     VStack(alignment: .leading, spacing: 12) {
-                        Toggle(isOn: commitBinding) {
+                        Toggle(isOn: self.commitBinding) {
                             VStack(alignment: .leading) {
                                 Text("Commit Attribution")
                                     .font(.body)
@@ -34,7 +34,7 @@ struct AttributionSettingsEditorView: View {
 
                         Divider()
 
-                        Toggle(isOn: pullRequestBinding) {
+                        Toggle(isOn: self.pullRequestBinding) {
                             VStack(alignment: .leading) {
                                 Text("Pull Request Attribution")
                                     .font(.body)
@@ -56,31 +56,31 @@ struct AttributionSettingsEditorView: View {
 
                         // Tag input area
                         FlowLayout(spacing: 8) {
-                            ForEach(viewModel.disallowedTools, id: \.self) { tool in
+                            ForEach(self.viewModel.disallowedTools, id: \.self) { tool in
                                 DisallowedToolTag(tool: tool) {
-                                    viewModel.removeDisallowedTool(tool)
+                                    self.viewModel.removeDisallowedTool(tool)
                                 }
                             }
 
                             // Add new tag
-                            if isAddingTool {
+                            if self.isAddingTool {
                                 AddToolInput(
-                                    toolName: $newToolName,
-                                    onAdd: addNewTool,
+                                    toolName: self.$newToolName,
+                                    onAdd: self.addNewTool,
                                     onCancel: {
-                                        isAddingTool = false
-                                        newToolName = ""
+                                        self.isAddingTool = false
+                                        self.newToolName = ""
                                     }
                                 )
                             } else {
                                 AddToolButton {
-                                    isAddingTool = true
+                                    self.isAddingTool = true
                                 }
                             }
                         }
                         .padding(.vertical, 4)
 
-                        if viewModel.disallowedTools.isEmpty, !isAddingTool {
+                        if self.viewModel.disallowedTools.isEmpty, !self.isAddingTool {
                             Text("No tools are disallowed")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
@@ -103,11 +103,11 @@ struct AttributionSettingsEditorView: View {
 
     private var commitBinding: Binding<Bool> {
         Binding(
-            get: { viewModel.attribution?.commits ?? false },
+            get: { self.viewModel.attribution?.commits ?? false },
             set: { newValue in
-                viewModel.updateAttribution(
+                self.viewModel.updateAttribution(
                     commits: newValue,
-                    pullRequests: viewModel.attribution?.pullRequests
+                    pullRequests: self.viewModel.attribution?.pullRequests
                 )
             }
         )
@@ -115,10 +115,10 @@ struct AttributionSettingsEditorView: View {
 
     private var pullRequestBinding: Binding<Bool> {
         Binding(
-            get: { viewModel.attribution?.pullRequests ?? false },
+            get: { self.viewModel.attribution?.pullRequests ?? false },
             set: { newValue in
-                viewModel.updateAttribution(
-                    commits: viewModel.attribution?.commits,
+                self.viewModel.updateAttribution(
+                    commits: self.viewModel.attribution?.commits,
                     pullRequests: newValue
                 )
             }
@@ -126,10 +126,12 @@ struct AttributionSettingsEditorView: View {
     }
 
     private func addNewTool() {
-        guard !newToolName.isEmpty else { return }
-        viewModel.addDisallowedTool(newToolName)
-        newToolName = ""
-        isAddingTool = false
+        guard !self.newToolName.isEmpty else {
+            return
+        }
+        self.viewModel.addDisallowedTool(self.newToolName)
+        self.newToolName = ""
+        self.isAddingTool = false
     }
 }
 
@@ -142,9 +144,9 @@ struct DisallowedToolTag: View {
 
     var body: some View {
         HStack(spacing: 4) {
-            Text(tool)
+            Text(self.tool)
                 .font(.system(.caption, design: .monospaced))
-            Button(action: onRemove) {
+            Button(action: self.onRemove) {
                 Image(systemName: "xmark")
                     .font(.caption2)
             }
@@ -161,27 +163,28 @@ struct DisallowedToolTag: View {
 /// Input field for adding a new disallowed tool.
 struct AddToolInput: View {
     @Binding var toolName: String
+
     let onAdd: () -> Void
     let onCancel: () -> Void
 
     var body: some View {
         HStack(spacing: 4) {
-            TextField("Tool name", text: $toolName)
+            TextField("Tool name", text: self.$toolName)
                 .textFieldStyle(.plain)
                 .font(.system(.caption, design: .monospaced))
                 .frame(minWidth: 80, maxWidth: 120)
                 .onSubmit {
-                    onAdd()
+                    self.onAdd()
                 }
 
-            Button(action: onAdd) {
+            Button(action: self.onAdd) {
                 Image(systemName: "checkmark")
                     .font(.caption2)
             }
             .buttonStyle(.plain)
-            .disabled(toolName.isEmpty)
+            .disabled(self.toolName.isEmpty)
 
-            Button(action: onCancel) {
+            Button(action: self.onCancel) {
                 Image(systemName: "xmark")
                     .font(.caption2)
             }
@@ -200,7 +203,7 @@ struct AddToolButton: View {
     let action: () -> Void
 
     var body: some View {
-        Button(action: action) {
+        Button(action: self.action) {
             HStack(spacing: 4) {
                 Image(systemName: "plus")
                     .font(.caption2)

--- a/Fig/Sources/Views/ClaudeMDView.swift
+++ b/Fig/Sources/Views/ClaudeMDView.swift
@@ -16,15 +16,15 @@ struct ClaudeMDView: View {
     var body: some View {
         HSplitView {
             // File hierarchy sidebar
-            claudeMDSidebar
+            self.claudeMDSidebar
                 .frame(minWidth: 180, idealWidth: 220, maxWidth: 280)
 
             // Content area
-            contentArea
+            self.contentArea
                 .frame(minWidth: 300)
         }
         .task {
-            await viewModel.loadFiles()
+            await self.viewModel.loadFiles()
         }
     }
 
@@ -44,7 +44,7 @@ struct ClaudeMDView: View {
                 Spacer()
                 Button {
                     Task {
-                        await viewModel.loadFiles()
+                        await self.viewModel.loadFiles()
                     }
                 } label: {
                     Image(systemName: "arrow.clockwise")
@@ -58,14 +58,14 @@ struct ClaudeMDView: View {
 
             Divider()
 
-            if viewModel.isLoading {
+            if self.viewModel.isLoading {
                 ProgressView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                List(selection: $viewModel.selectedFileID) {
+                List(selection: self.$viewModel.selectedFileID) {
                     // Global section
                     Section("Global") {
-                        ForEach(viewModel.files.filter { $0.level == .global }) { file in
+                        ForEach(self.viewModel.files.filter { $0.level == .global }) { file in
                             ClaudeMDFileRow(file: file)
                                 .tag(file.id)
                         }
@@ -74,7 +74,7 @@ struct ClaudeMDView: View {
                     // Project section
                     Section("Project") {
                         ForEach(
-                            viewModel.files.filter { $0.level != .global }
+                            self.viewModel.files.filter { $0.level != .global }
                         ) { file in
                             ClaudeMDFileRow(file: file)
                                 .tag(file.id)
@@ -82,8 +82,8 @@ struct ClaudeMDView: View {
                     }
                 }
                 .listStyle(.sidebar)
-                .onChange(of: viewModel.selectedFileID) { _, _ in
-                    viewModel.cancelEditing()
+                .onChange(of: self.viewModel.selectedFileID) { _, _ in
+                    self.viewModel.cancelEditing()
                 }
             }
         }
@@ -95,17 +95,17 @@ struct ClaudeMDView: View {
         VStack(spacing: 0) {
             if let file = viewModel.selectedFile {
                 // Toolbar
-                contentToolbar(for: file)
+                self.contentToolbar(for: file)
 
                 Divider()
 
                 // Content
-                if viewModel.isEditing {
-                    editorView
+                if self.viewModel.isEditing {
+                    self.editorView
                 } else if file.exists {
-                    previewView(for: file)
+                    self.previewView(for: file)
                 } else {
-                    emptyFileView(for: file)
+                    self.emptyFileView(for: file)
                 }
             } else {
                 ContentUnavailableView(
@@ -115,6 +115,15 @@ struct ClaudeMDView: View {
                 )
             }
         }
+    }
+
+    // MARK: - Editor
+
+    private var editorView: some View {
+        TextEditor(text: self.$viewModel.editContent)
+            .font(.system(.body, design: .monospaced))
+            .scrollContentBackground(.hidden)
+            .padding(4)
     }
 
     private func contentToolbar(for file: ClaudeMDFile) -> some View {
@@ -136,28 +145,28 @@ struct ClaudeMDView: View {
             }
 
             // Action buttons
-            if viewModel.isEditing {
+            if self.viewModel.isEditing {
                 Button("Cancel") {
-                    viewModel.cancelEditing()
+                    self.viewModel.cancelEditing()
                 }
 
                 Button("Save") {
                     Task {
-                        await viewModel.saveSelectedFile()
+                        await self.viewModel.saveSelectedFile()
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(viewModel.editContent == file.content)
+                .disabled(self.viewModel.editContent == file.content)
             } else if file.exists {
                 Button {
-                    viewModel.startEditing()
+                    self.viewModel.startEditing()
                 } label: {
                     Label("Edit", systemImage: "pencil")
                 }
             } else {
                 Button {
                     Task {
-                        await viewModel.createFile(at: file.level)
+                        await self.viewModel.createFile(at: file.level)
                     }
                 } label: {
                     Label("Create", systemImage: "plus")
@@ -181,15 +190,6 @@ struct ClaudeMDView: View {
         }
     }
 
-    // MARK: - Editor
-
-    private var editorView: some View {
-        TextEditor(text: $viewModel.editContent)
-            .font(.system(.body, design: .monospaced))
-            .scrollContentBackground(.hidden)
-            .padding(4)
-    }
-
     // MARK: - Empty State
 
     private func emptyFileView(for file: ClaudeMDFile) -> some View {
@@ -200,13 +200,12 @@ struct ClaudeMDView: View {
         } actions: {
             Button("Create File") {
                 Task {
-                    await viewModel.createFile(at: file.level)
+                    await self.viewModel.createFile(at: file.level)
                 }
             }
             .buttonStyle(.borderedProminent)
         }
     }
-
 }
 
 // MARK: - ClaudeMDFileRow
@@ -217,12 +216,12 @@ struct ClaudeMDFileRow: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            Image(systemName: file.exists ? "doc.text.fill" : "doc.badge.plus")
-                .foregroundStyle(file.exists ? .blue : .secondary)
+            Image(systemName: self.file.exists ? "doc.text.fill" : "doc.badge.plus")
+                .foregroundStyle(self.file.exists ? .blue : .secondary)
                 .frame(width: 16)
 
             VStack(alignment: .leading, spacing: 1) {
-                Text(file.level.displayName)
+                Text(self.file.level.displayName)
                     .font(.body)
                     .lineLimit(1)
 
@@ -236,8 +235,8 @@ struct ClaudeMDFileRow: View {
 
             Spacer()
 
-            if file.exists {
-                if file.isTrackedByGit {
+            if self.file.exists {
+                if self.file.isTrackedByGit {
                     Image(systemName: "checkmark.circle.fill")
                         .font(.caption2)
                         .foregroundStyle(.green)
@@ -262,10 +261,10 @@ struct GitStatusBadge: View {
 
     var body: some View {
         HStack(spacing: 4) {
-            Image(systemName: isTracked ? "checkmark.circle.fill" : "circle.dashed")
-                .foregroundStyle(isTracked ? .green : .orange)
+            Image(systemName: self.isTracked ? "checkmark.circle.fill" : "circle.dashed")
+                .foregroundStyle(self.isTracked ? .green : .orange)
                 .font(.caption)
-            Text(isTracked ? "In git" : "Untracked")
+            Text(self.isTracked ? "In git" : "Untracked")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/Fig/Sources/Views/ConfigExportView.swift
+++ b/Fig/Sources/Views/ConfigExportView.swift
@@ -8,12 +8,10 @@ struct ConfigExportView: View {
 
     @Bindable var viewModel: ConfigExportViewModel
 
-    @Environment(\.dismiss) private var dismiss
-
     var body: some View {
         VStack(spacing: 0) {
             // Header
-            header
+            self.header
 
             Divider()
 
@@ -21,21 +19,21 @@ struct ConfigExportView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
                     // Component selection
-                    componentSelectionSection
+                    self.componentSelectionSection
 
                     // Sensitive data warning
-                    if viewModel.includeLocalSettings {
-                        sensitiveDataWarning
+                    if self.viewModel.includeLocalSettings {
+                        self.sensitiveDataWarning
                     }
 
                     // Error message
                     if let error = viewModel.errorMessage {
-                        errorSection(error: error)
+                        self.errorSection(error: error)
                     }
 
                     // Success message
-                    if viewModel.exportSuccessful {
-                        successSection
+                    if self.viewModel.exportSuccessful {
+                        self.successSection
                     }
                 }
                 .padding()
@@ -44,15 +42,17 @@ struct ConfigExportView: View {
             Divider()
 
             // Footer
-            footer
+            self.footer
         }
         .frame(width: 450, height: 400)
         .task {
-            await viewModel.loadAvailableComponents()
+            await self.viewModel.loadAvailableComponents()
         }
     }
 
     // MARK: Private
+
+    @Environment(\.dismiss) private var dismiss
 
     private var header: some View {
         HStack {
@@ -63,7 +63,7 @@ struct ConfigExportView: View {
             VStack(alignment: .leading) {
                 Text("Export Configuration")
                     .font(.headline)
-                Text(viewModel.projectName)
+                Text(self.viewModel.projectName)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
@@ -80,22 +80,22 @@ struct ConfigExportView: View {
                     .font(.subheadline)
                     .fontWeight(.medium)
 
-                if viewModel.availableComponents.isEmpty {
+                if self.viewModel.availableComponents.isEmpty {
                     Text("No configuration found in this project.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 } else {
                     ForEach(ConfigBundleComponent.allCases) { component in
-                        if viewModel.availableComponents.contains(component) {
+                        if self.viewModel.availableComponents.contains(component) {
                             ComponentToggle(
                                 component: component,
                                 isSelected: Binding(
-                                    get: { viewModel.selectedComponents.contains(component) },
+                                    get: { self.viewModel.selectedComponents.contains(component) },
                                     set: { selected in
                                         if selected {
-                                            viewModel.selectedComponents.insert(component)
+                                            self.viewModel.selectedComponents.insert(component)
                                         } else {
-                                            viewModel.selectedComponents.remove(component)
+                                            self.viewModel.selectedComponents.remove(component)
                                         }
                                     }
                                 )
@@ -123,13 +123,13 @@ struct ConfigExportView: View {
 
                 Text(
                     "The local settings file (settings.local.json) may contain API keys, " +
-                    "tokens, or other sensitive information. Only share this export " +
-                    "file with trusted parties."
+                        "tokens, or other sensitive information. Only share this export " +
+                        "file with trusted parties."
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-                Toggle(isOn: $viewModel.acknowledgedSensitiveData) {
+                Toggle(isOn: self.$viewModel.acknowledgedSensitiveData) {
                     Text("I understand the risks")
                         .font(.subheadline)
                 }
@@ -137,21 +137,6 @@ struct ConfigExportView: View {
             .padding(.vertical, 4)
         } label: {
             Label("Security Warning", systemImage: "lock.shield")
-        }
-    }
-
-    @ViewBuilder
-    private func errorSection(error: String) -> some View {
-        GroupBox {
-            HStack {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundStyle(.red)
-                Text(error)
-                    .foregroundStyle(.red)
-            }
-            .padding(.vertical, 4)
-        } label: {
-            Label("Error", systemImage: "xmark.octagon")
         }
     }
 
@@ -181,30 +166,44 @@ struct ConfigExportView: View {
     private var footer: some View {
         HStack {
             Button("Cancel") {
-                dismiss()
+                self.dismiss()
             }
             .keyboardShortcut(.cancelAction)
 
             Spacer()
 
-            if viewModel.exportSuccessful {
+            if self.viewModel.exportSuccessful {
                 Button("Done") {
-                    dismiss()
+                    self.dismiss()
                 }
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
             } else {
                 Button("Export...") {
                     Task {
-                        await viewModel.performExport()
+                        await self.viewModel.performExport()
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(!viewModel.canExport)
+                .disabled(!self.viewModel.canExport)
                 .keyboardShortcut(.defaultAction)
             }
         }
         .padding()
+    }
+
+    private func errorSection(error: String) -> some View {
+        GroupBox {
+            HStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+                Text(error)
+                    .foregroundStyle(.red)
+            }
+            .padding(.vertical, 4)
+        } label: {
+            Label("Error", systemImage: "xmark.octagon")
+        }
     }
 }
 
@@ -213,15 +212,16 @@ struct ConfigExportView: View {
 /// Toggle for selecting a component with info.
 private struct ComponentToggle: View {
     let component: ConfigBundleComponent
+
     @Binding var isSelected: Bool
 
     var body: some View {
-        Toggle(isOn: $isSelected) {
+        Toggle(isOn: self.$isSelected) {
             HStack {
-                Image(systemName: component.icon)
+                Image(systemName: self.component.icon)
                     .frame(width: 20)
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(component.displayName)
+                    Text(self.component.displayName)
                         .font(.subheadline)
                     if let warning = component.sensitiveWarning {
                         Text(warning)

--- a/Fig/Sources/Views/ConfigImportView.swift
+++ b/Fig/Sources/Views/ConfigImportView.swift
@@ -8,19 +8,17 @@ struct ConfigImportView: View {
 
     @Bindable var viewModel: ConfigImportViewModel
 
-    @Environment(\.dismiss) private var dismiss
-
     var body: some View {
         VStack(spacing: 0) {
             // Header with step indicator
-            header
+            self.header
 
             Divider()
 
             // Step content
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
-                    stepContent
+                    self.stepContent
                 }
                 .padding()
             }
@@ -28,12 +26,14 @@ struct ConfigImportView: View {
             Divider()
 
             // Footer
-            footer
+            self.footer
         }
         .frame(width: 500, height: 500)
     }
 
     // MARK: Private
+
+    @Environment(\.dismiss) private var dismiss
 
     private var header: some View {
         VStack(spacing: 12) {
@@ -45,7 +45,7 @@ struct ConfigImportView: View {
                 VStack(alignment: .leading) {
                     Text("Import Configuration")
                         .font(.headline)
-                    Text(viewModel.projectName)
+                    Text(self.viewModel.projectName)
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }
@@ -58,13 +58,13 @@ struct ConfigImportView: View {
                 ForEach(Array(ImportWizardStep.allCases.enumerated()), id: \.element) { index, step in
                     if index > 0 {
                         Rectangle()
-                            .fill(step.rawValue <= viewModel.currentStep.rawValue
+                            .fill(step.rawValue <= self.viewModel.currentStep.rawValue
                                 ? Color.accentColor : Color.secondary.opacity(0.3))
                             .frame(height: 2)
                     }
 
                     Circle()
-                        .fill(step.rawValue <= viewModel.currentStep.rawValue
+                        .fill(step.rawValue <= self.viewModel.currentStep.rawValue
                             ? Color.accentColor : Color.secondary.opacity(0.3))
                         .frame(width: 10, height: 10)
                 }
@@ -76,17 +76,17 @@ struct ConfigImportView: View {
 
     @ViewBuilder
     private var stepContent: some View {
-        switch viewModel.currentStep {
+        switch self.viewModel.currentStep {
         case .selectFile:
-            selectFileStep
+            self.selectFileStep
         case .selectComponents:
-            selectComponentsStep
+            self.selectComponentsStep
         case .resolveConflicts:
-            resolveConflictsStep
+            self.resolveConflictsStep
         case .preview:
-            previewStep
+            self.previewStep
         case .complete:
-            completeStep
+            self.completeStep
         }
     }
 
@@ -143,13 +143,13 @@ struct ConfigImportView: View {
 
                 Button("Choose Different File...") {
                     Task {
-                        await viewModel.selectFile()
+                        await self.viewModel.selectFile()
                     }
                 }
             } else {
                 Button {
                     Task {
-                        await viewModel.selectFile()
+                        await self.viewModel.selectFile()
                     }
                 } label: {
                     VStack(spacing: 8) {
@@ -163,7 +163,7 @@ struct ConfigImportView: View {
                 .buttonStyle(.bordered)
             }
 
-            if viewModel.isLoading {
+            if self.viewModel.isLoading {
                 ProgressView("Loading bundle...")
             }
 
@@ -186,14 +186,14 @@ struct ConfigImportView: View {
 
             GroupBox {
                 VStack(alignment: .leading, spacing: 12) {
-                    ForEach(viewModel.availableComponents) { component in
+                    ForEach(self.viewModel.availableComponents) { component in
                         Toggle(isOn: Binding(
-                            get: { viewModel.selectedComponents.contains(component) },
+                            get: { self.viewModel.selectedComponents.contains(component) },
                             set: { selected in
                                 if selected {
-                                    viewModel.selectedComponents.insert(component)
+                                    self.viewModel.selectedComponents.insert(component)
                                 } else {
-                                    viewModel.selectedComponents.remove(component)
+                                    self.viewModel.selectedComponents.remove(component)
                                 }
                             }
                         )) {
@@ -218,7 +218,7 @@ struct ConfigImportView: View {
             }
 
             // Sensitive data warning
-            if viewModel.selectedComponents.contains(.localSettings) {
+            if self.viewModel.selectedComponents.contains(.localSettings) {
                 GroupBox {
                     VStack(alignment: .leading, spacing: 8) {
                         HStack {
@@ -229,7 +229,7 @@ struct ConfigImportView: View {
                         }
                         .font(.subheadline)
 
-                        Toggle(isOn: $viewModel.acknowledgedSensitiveData) {
+                        Toggle(isOn: self.$viewModel.acknowledgedSensitiveData) {
                             Text("I trust this bundle and want to import it")
                                 .font(.subheadline)
                         }
@@ -247,7 +247,7 @@ struct ConfigImportView: View {
             Text("The following conflicts were detected. Choose how to resolve them.")
                 .font(.subheadline)
 
-            ForEach(viewModel.conflicts) { conflict in
+            ForEach(self.viewModel.conflicts) { conflict in
                 GroupBox {
                     VStack(alignment: .leading, spacing: 8) {
                         HStack {
@@ -257,8 +257,8 @@ struct ConfigImportView: View {
                         }
 
                         Picker("Resolution", selection: Binding(
-                            get: { viewModel.resolutions[conflict.component] ?? .merge },
-                            set: { viewModel.resolutions[conflict.component] = $0 }
+                            get: { self.viewModel.resolutions[conflict.component] ?? .merge },
+                            set: { self.viewModel.resolutions[conflict.component] = $0 }
                         )) {
                             ForEach(ImportConflict.ImportResolution.allCases) { resolution in
                                 Text(resolution.displayName).tag(resolution)
@@ -281,7 +281,7 @@ struct ConfigImportView: View {
 
             GroupBox {
                 VStack(alignment: .leading, spacing: 8) {
-                    ForEach(Array(viewModel.selectedComponents)) { component in
+                    ForEach(Array(self.viewModel.selectedComponents)) { component in
                         HStack {
                             Image(systemName: "checkmark.circle.fill")
                                 .foregroundStyle(.green)
@@ -299,7 +299,7 @@ struct ConfigImportView: View {
                 Label("Components to Import", systemImage: "list.bullet")
             }
 
-            if viewModel.hasSensitiveData {
+            if self.viewModel.hasSensitiveData {
                 HStack {
                     Image(systemName: "lock.shield")
                         .foregroundStyle(.orange)
@@ -408,33 +408,33 @@ struct ConfigImportView: View {
 
     private var footer: some View {
         HStack {
-            if viewModel.canGoBack {
+            if self.viewModel.canGoBack {
                 Button("Back") {
-                    viewModel.previousStep()
+                    self.viewModel.previousStep()
                 }
             }
 
             Spacer()
 
-            if viewModel.currentStep == .complete {
+            if self.viewModel.currentStep == .complete {
                 Button("Done") {
-                    dismiss()
+                    self.dismiss()
                 }
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
             } else {
                 Button("Cancel") {
-                    dismiss()
+                    self.dismiss()
                 }
                 .keyboardShortcut(.cancelAction)
 
-                Button(viewModel.currentStep == .preview ? "Import" : "Next") {
+                Button(self.viewModel.currentStep == .preview ? "Import" : "Next") {
                     Task {
-                        await viewModel.nextStep()
+                        await self.viewModel.nextStep()
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(!viewModel.canProceed || viewModel.isImporting)
+                .disabled(!self.viewModel.canProceed || self.viewModel.isImporting)
                 .keyboardShortcut(.defaultAction)
             }
         }

--- a/Fig/Sources/Views/ConfigTabViews.swift
+++ b/Fig/Sources/Views/ConfigTabViews.swift
@@ -11,22 +11,22 @@ struct SourceBadge: View {
 
     var body: some View {
         HStack(spacing: 2) {
-            Image(systemName: source.icon)
+            Image(systemName: self.source.icon)
                 .font(.caption2)
-            Text(source.label)
+            Text(self.source.label)
                 .font(.caption2)
         }
         .padding(.horizontal, 6)
         .padding(.vertical, 2)
-        .background(backgroundColor.opacity(0.2), in: RoundedRectangle(cornerRadius: 4))
-        .foregroundStyle(backgroundColor)
-        .accessibilityLabel("Source: \(source.label)")
+        .background(self.backgroundColor.opacity(0.2), in: RoundedRectangle(cornerRadius: 4))
+        .foregroundStyle(self.backgroundColor)
+        .accessibilityLabel("Source: \(self.source.label)")
     }
 
     // MARK: Private
 
     private var backgroundColor: Color {
-        switch source {
+        switch self.source {
         case .global:
             .blue
         case .projectShared:
@@ -58,7 +58,7 @@ struct PermissionsTabView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
                 // Source legend for project views
-                if allPermissions != nil {
+                if self.allPermissions != nil {
                     SourceLegend()
                 }
 
@@ -69,7 +69,7 @@ struct PermissionsTabView: View {
                             .font(.headline)
                             .foregroundStyle(.green)
 
-                        let allowRules = allowPermissions
+                        let allowRules = self.allowPermissions
                         if allowRules.isEmpty {
                             Text("No allow rules configured.")
                                 .foregroundStyle(.secondary)
@@ -80,13 +80,13 @@ struct PermissionsTabView: View {
                                     rule: item.rule,
                                     type: .allow,
                                     source: item.source,
-                                    isOverride: isRuleOverridingGlobal(
+                                    isOverride: self.isRuleOverridingGlobal(
                                         rule: item.rule,
                                         type: .allow,
                                         source: item.source
                                     ),
-                                    onPromoteToGlobal: onPromoteToGlobal,
-                                    onCopyToScope: onCopyToScope
+                                    onPromoteToGlobal: self.onPromoteToGlobal,
+                                    onCopyToScope: self.onCopyToScope
                                 )
                             }
                         }
@@ -101,7 +101,7 @@ struct PermissionsTabView: View {
                             .font(.headline)
                             .foregroundStyle(.red)
 
-                        let denyRules = denyPermissions
+                        let denyRules = self.denyPermissions
                         if denyRules.isEmpty {
                             Text("No deny rules configured.")
                                 .foregroundStyle(.secondary)
@@ -112,13 +112,13 @@ struct PermissionsTabView: View {
                                     rule: item.rule,
                                     type: .deny,
                                     source: item.source,
-                                    isOverride: isRuleOverridingGlobal(
+                                    isOverride: self.isRuleOverridingGlobal(
                                         rule: item.rule,
                                         type: .deny,
                                         source: item.source
                                     ),
-                                    onPromoteToGlobal: onPromoteToGlobal,
-                                    onCopyToScope: onCopyToScope
+                                    onPromoteToGlobal: self.onPromoteToGlobal,
+                                    onCopyToScope: self.onCopyToScope
                                 )
                             }
                         }
@@ -156,7 +156,9 @@ struct PermissionsTabView: View {
 
     /// Checks if a project-level rule also exists at the global level.
     private func isRuleOverridingGlobal(rule: String, type: PermissionType, source: ConfigSource) -> Bool {
-        guard source != .global, let allPermissions else { return false }
+        guard source != .global, let allPermissions else {
+            return false
+        }
         return allPermissions.contains { $0.rule == rule && $0.type == type && $0.source == .global }
     }
 }
@@ -174,16 +176,16 @@ struct PermissionRuleRow: View {
 
     var body: some View {
         HStack {
-            Image(systemName: type.icon)
-                .foregroundStyle(type == .allow ? .green : .red)
+            Image(systemName: self.type.icon)
+                .foregroundStyle(self.type == .allow ? .green : .red)
                 .frame(width: 20)
 
-            Text(rule)
+            Text(self.rule)
                 .font(.system(.body, design: .monospaced))
                 .lineLimit(1)
                 .truncationMode(.middle)
 
-            if isOverride {
+            if self.isOverride {
                 Image(systemName: "arrow.up.arrow.down")
                     .foregroundStyle(.orange)
                     .font(.caption2)
@@ -192,34 +194,36 @@ struct PermissionRuleRow: View {
 
             Spacer()
 
-            SourceBadge(source: source)
+            SourceBadge(source: self.source)
         }
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(type == .allow ? "Allow" : "Deny") rule: \(rule), source: \(source.label)")
+        .accessibilityLabel(
+            "\(self.type == .allow ? "Allow" : "Deny") rule: \(self.rule), source: \(self.source.label)"
+        )
         .contextMenu {
             Button {
                 NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(rule, forType: .string)
+                NSPasteboard.general.setString(self.rule, forType: .string)
             } label: {
                 Label("Copy Rule", systemImage: "doc.on.doc")
             }
 
-            if source != .global, onPromoteToGlobal != nil {
+            if self.source != .global, self.onPromoteToGlobal != nil {
                 Divider()
 
                 Button {
-                    onPromoteToGlobal?(rule, type)
+                    self.onPromoteToGlobal?(self.rule, self.type)
                 } label: {
                     Label("Promote to Global", systemImage: "arrow.up.to.line")
                 }
             }
 
-            if source == .projectShared || source == .projectLocal {
-                let otherScope: ConfigSource = source == .projectShared ? .projectLocal : .projectShared
-                if onCopyToScope != nil {
+            if self.source == .projectShared || self.source == .projectLocal {
+                let otherScope: ConfigSource = self.source == .projectShared ? .projectLocal : .projectShared
+                if self.onCopyToScope != nil {
                     Button {
-                        onCopyToScope?(rule, type, otherScope)
+                        self.onCopyToScope?(self.rule, self.type, otherScope)
                     } label: {
                         Label("Copy to \(otherScope.label)", systemImage: "arrow.left.arrow.right")
                     }
@@ -239,20 +243,20 @@ struct EnvironmentTabView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                if !envVars.isEmpty {
+                if !self.envVars.isEmpty {
                     SourceLegend()
                 }
 
-                if envVars.isEmpty {
+                if self.envVars.isEmpty {
                     ContentUnavailableView(
                         "No Environment Variables",
                         systemImage: "list.bullet.rectangle",
-                        description: Text(emptyMessage)
+                        description: Text(self.emptyMessage)
                     )
                 } else {
                     GroupBox {
                         VStack(alignment: .leading, spacing: 0) {
-                            ForEach(Array(envVars.enumerated()), id: \.offset) { index, item in
+                            ForEach(Array(self.envVars.enumerated()), id: \.offset) { index, item in
                                 if index > 0 {
                                     Divider()
                                 }
@@ -285,7 +289,7 @@ struct EnvironmentVariableRow: View {
 
     var body: some View {
         HStack(alignment: .top) {
-            Text(key)
+            Text(self.key)
                 .font(.system(.body, design: .monospaced))
                 .fontWeight(.medium)
                 .frame(minWidth: 200, alignment: .leading)
@@ -294,31 +298,31 @@ struct EnvironmentVariableRow: View {
                 .foregroundStyle(.secondary)
 
             Group {
-                if isValueVisible || !isSensitive {
-                    Text(value)
+                if self.isValueVisible || !self.isSensitive {
+                    Text(self.value)
                         .font(.system(.body, design: .monospaced))
                         .lineLimit(2)
                         .truncationMode(.middle)
                 } else {
-                    Text(String(repeating: "\u{2022}", count: min(value.count, 20)))
+                    Text(String(repeating: "\u{2022}", count: min(self.value.count, 20)))
                         .font(.system(.body, design: .monospaced))
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            if isSensitive {
+            if self.isSensitive {
                 Button {
-                    isValueVisible.toggle()
+                    self.isValueVisible.toggle()
                 } label: {
-                    Image(systemName: isValueVisible ? "eye.slash" : "eye")
+                    Image(systemName: self.isValueVisible ? "eye.slash" : "eye")
                         .font(.caption)
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel(isValueVisible ? "Hide value" : "Show value")
-                .accessibilityHint("Toggles visibility of sensitive value for \(key)")
+                .accessibilityLabel(self.isValueVisible ? "Hide value" : "Show value")
+                .accessibilityHint("Toggles visibility of sensitive value for \(self.key)")
             }
 
-            SourceBadge(source: source)
+            SourceBadge(source: self.source)
         }
         .padding(.vertical, 8)
     }
@@ -329,7 +333,7 @@ struct EnvironmentVariableRow: View {
 
     private var isSensitive: Bool {
         let sensitivePatterns = ["token", "key", "secret", "password", "credential", "api"]
-        let lowercaseKey = key.lowercased()
+        let lowercaseKey = self.key.lowercased()
         return sensitivePatterns.contains { lowercaseKey.contains($0) }
     }
 }
@@ -348,20 +352,18 @@ struct MCPServersTabView: View {
     var onCopyAll: (() -> Void)?
     var onPasteServers: (() -> Void)?
 
-    // MARK: Internal
-
     var hasToolbar: Bool {
-        onAdd != nil || onCopyAll != nil || onPasteServers != nil
+        self.onAdd != nil || self.onCopyAll != nil || self.onPasteServers != nil
     }
 
     var body: some View {
         VStack(spacing: 0) {
             // Toolbar
-            if hasToolbar {
+            if self.hasToolbar {
                 HStack {
-                    if onPasteServers != nil {
+                    if self.onPasteServers != nil {
                         Button {
-                            onPasteServers?()
+                            self.onPasteServers?()
                         } label: {
                             Label("Import from JSON", systemImage: "doc.on.clipboard")
                         }
@@ -370,18 +372,18 @@ struct MCPServersTabView: View {
 
                     Spacer()
 
-                    if onCopyAll != nil, !servers.isEmpty {
+                    if self.onCopyAll != nil, !self.servers.isEmpty {
                         Button {
-                            onCopyAll?()
+                            self.onCopyAll?()
                         } label: {
                             Label("Copy All as JSON", systemImage: "doc.on.doc")
                         }
                         .buttonStyle(.bordered)
                     }
 
-                    if onAdd != nil {
+                    if self.onAdd != nil {
                         Button {
-                            onAdd?()
+                            self.onAdd?()
                         } label: {
                             Label("Add Server", systemImage: "plus")
                         }
@@ -396,30 +398,30 @@ struct MCPServersTabView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-                    if !servers.isEmpty {
+                    if !self.servers.isEmpty {
                         SourceLegend()
                     }
 
-                    if servers.isEmpty {
+                    if self.servers.isEmpty {
                         ContentUnavailableView(
                             "No MCP Servers",
                             systemImage: "server.rack",
-                            description: Text(emptyMessage)
+                            description: Text(self.emptyMessage)
                         )
                     } else {
-                        ForEach(Array(servers.enumerated()), id: \.offset) { _, item in
+                        ForEach(Array(self.servers.enumerated()), id: \.offset) { _, item in
                             MCPServerCard(
                                 name: item.name,
                                 server: item.server,
                                 source: item.source,
-                                onEdit: onEdit != nil ? {
-                                    onEdit?(item.name, item.server, item.source)
+                                onEdit: self.onEdit != nil ? {
+                                    self.onEdit?(item.name, item.server, item.source)
                                 } : nil,
-                                onDelete: onDelete != nil ? {
-                                    onDelete?(item.name, item.source)
+                                onDelete: self.onDelete != nil ? {
+                                    self.onDelete?(item.name, item.source)
                                 } : nil,
-                                onCopy: onCopy != nil ? {
-                                    onCopy?(item.name, item.server)
+                                onCopy: self.onCopy != nil ? {
+                                    self.onCopy?(item.name, item.server)
                                 } : nil
                             )
                         }
@@ -452,13 +454,13 @@ struct MCPServerCard: View {
             VStack(alignment: .leading, spacing: 8) {
                 // Header
                 HStack {
-                    Image(systemName: server.isHTTP ? "globe" : "terminal")
-                        .foregroundStyle(server.isHTTP ? .blue : .green)
+                    Image(systemName: self.server.isHTTP ? "globe" : "terminal")
+                        .foregroundStyle(self.server.isHTTP ? .blue : .green)
 
-                    Text(name)
+                    Text(self.name)
                         .font(.headline)
 
-                    Text(server.isHTTP ? "HTTP" : "Stdio")
+                    Text(self.server.isHTTP ? "HTTP" : "Stdio")
                         .font(.caption)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
@@ -468,45 +470,48 @@ struct MCPServerCard: View {
 
                     // Action buttons
                     HStack(spacing: 4) {
+                        // Health check button
+                        MCPHealthCheckButton(serverName: self.name, server: self.server)
+
                         // Copy to clipboard
                         Button {
-                            copyToClipboard()
+                            self.copyToClipboard()
                         } label: {
                             Image(systemName: "doc.on.doc")
                                 .font(.caption)
                         }
                         .buttonStyle(.plain)
                         .help("Copy as JSON")
-                        .accessibilityLabel("Copy \(name) as JSON")
+                        .accessibilityLabel("Copy \(self.name) as JSON")
 
                         // Copy to project
-                        if onCopy != nil {
+                        if self.onCopy != nil {
                             Button {
-                                onCopy?()
+                                self.onCopy?()
                             } label: {
                                 Image(systemName: "arrow.right.doc.on.clipboard")
                                     .font(.caption)
                             }
                             .buttonStyle(.plain)
                             .help("Copy to...")
-                            .accessibilityLabel("Copy \(name) to another project")
+                            .accessibilityLabel("Copy \(self.name) to another project")
                         }
 
-                        if onEdit != nil {
+                        if self.onEdit != nil {
                             Button {
-                                onEdit?()
+                                self.onEdit?()
                             } label: {
                                 Image(systemName: "pencil")
                                     .font(.caption)
                             }
                             .buttonStyle(.plain)
                             .help("Edit server")
-                            .accessibilityLabel("Edit \(name)")
+                            .accessibilityLabel("Edit \(self.name)")
                         }
 
-                        if onDelete != nil {
+                        if self.onDelete != nil {
                             Button {
-                                onDelete?()
+                                self.onDelete?()
                             } label: {
                                 Image(systemName: "trash")
                                     .font(.caption)
@@ -514,28 +519,29 @@ struct MCPServerCard: View {
                             }
                             .buttonStyle(.plain)
                             .help("Delete server")
-                            .accessibilityLabel("Delete \(name)")
+                            .accessibilityLabel("Delete \(self.name)")
                         }
                     }
 
-                    SourceBadge(source: source)
+                    SourceBadge(source: self.source)
 
-                    if hasExpandableContent {
+                    if self.hasExpandableContent {
                         Button {
                             withAnimation {
-                                isExpanded.toggle()
+                                self.isExpanded.toggle()
                             }
                         } label: {
-                            Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                            Image(systemName: self.isExpanded ? "chevron.up" : "chevron.down")
                                 .font(.caption)
                         }
                         .buttonStyle(.plain)
-                        .accessibilityLabel(isExpanded ? "Collapse \(name) details" : "Expand \(name) details")
+                        .accessibilityLabel(self
+                            .isExpanded ? "Collapse \(self.name) details" : "Expand \(self.name) details")
                     }
                 }
 
                 // Summary line
-                if server.isHTTP {
+                if self.server.isHTTP {
                     if let url = server.url {
                         Text(url)
                             .font(.system(.caption, design: .monospaced))
@@ -555,18 +561,58 @@ struct MCPServerCard: View {
                     }
                 }
 
+                // Expanded details
+                if self.isExpanded {
+                    Divider()
+
+                    if self.server.isHTTP {
+                        if let headers = server.headers, !headers.isEmpty {
+                            Text("Headers:")
+                                .font(.caption)
+                                .fontWeight(.medium)
+                            ForEach(Array(headers.keys.sorted()), id: \.self) { key in
+                                HStack {
+                                    Text(key)
+                                        .font(.system(.caption, design: .monospaced))
+                                    Text(":")
+                                        .foregroundStyle(.secondary)
+                                    Text(self.maskSensitiveValue(key: key, value: headers[key] ?? ""))
+                                        .font(.system(.caption, design: .monospaced))
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    } else {
+                        if let env = server.env, !env.isEmpty {
+                            Text("Environment:")
+                                .font(.caption)
+                                .fontWeight(.medium)
+                            ForEach(Array(env.keys.sorted()), id: \.self) { key in
+                                HStack {
+                                    Text(key)
+                                        .font(.system(.caption, design: .monospaced))
+                                    Text("=")
+                                        .foregroundStyle(.secondary)
+                                    Text(self.maskSensitiveValue(key: key, value: env[key] ?? ""))
+                                        .font(.system(.caption, design: .monospaced))
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
         .contextMenu {
             Button {
-                copyToClipboard()
+                self.copyToClipboard()
             } label: {
                 Label("Copy as JSON", systemImage: "doc.on.doc")
             }
 
-            if onCopy != nil {
+            if self.onCopy != nil {
                 Button {
-                    onCopy?()
+                    self.onCopy?()
                 } label: {
                     Label("Copy to...", systemImage: "arrow.right.doc.on.clipboard")
                 }
@@ -574,18 +620,18 @@ struct MCPServerCard: View {
 
             Divider()
 
-            if onEdit != nil {
+            if self.onEdit != nil {
                 Button {
-                    onEdit?()
+                    self.onEdit?()
                 } label: {
                     Label("Edit", systemImage: "pencil")
                 }
             }
 
-            if onDelete != nil {
+            if self.onDelete != nil {
                 Divider()
                 Button(role: .destructive) {
-                    onDelete?()
+                    self.onDelete?()
                 } label: {
                     Label("Delete", systemImage: "trash")
                 }
@@ -598,10 +644,10 @@ struct MCPServerCard: View {
     @State private var isExpanded = false
 
     private var hasExpandableContent: Bool {
-        if server.isHTTP {
-            return server.headers?.isEmpty == false
+        if self.server.isHTTP {
+            self.server.headers?.isEmpty == false
         } else {
-            return server.env?.isEmpty == false
+            self.server.env?.isEmpty == false
         }
     }
 
@@ -615,15 +661,31 @@ struct MCPServerCard: View {
     }
 
     private func copyToClipboard() {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode([name: self.server])
 
-        if let data = try? encoder.encode([name: server]),
-           let jsonString = String(data: data, encoding: .utf8)
-        {
+            guard let jsonString = String(data: data, encoding: .utf8) else {
+                NotificationManager.shared.showError(
+                    "Copy failed",
+                    message: "Failed to convert server data to text"
+                )
+                return
+            }
+
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(jsonString, forType: .string)
-            NotificationManager.shared.showSuccess("Copied to clipboard", message: "Server '\(name)' copied as JSON")
+            NotificationManager.shared.showSuccess(
+                "Copied to clipboard",
+                message: "Server '\(self.name)' copied as JSON"
+            )
+        } catch {
+            Log.general.error("Failed to encode server '\(self.name)': \(error)")
+            NotificationManager.shared.showError(
+                "Copy failed",
+                message: "Failed to encode server configuration"
+            )
         }
     }
 }
@@ -643,7 +705,7 @@ struct HooksTabView: View {
             VStack(alignment: .leading, spacing: 16) {
                 SourceLegend()
 
-                if allHooksEmpty {
+                if self.allHooksEmpty {
                     ContentUnavailableView(
                         "No Hooks Configured",
                         systemImage: "arrow.triangle.branch",
@@ -653,12 +715,12 @@ struct HooksTabView: View {
                     )
                 } else {
                     // List all hook events
-                    ForEach(allHookEvents, id: \.self) { event in
+                    ForEach(self.allHookEvents, id: \.self) { event in
                         HookEventSection(
                             event: event,
-                            globalGroups: globalHooks?[event],
-                            projectGroups: projectHooks?[event],
-                            localGroups: localHooks?[event]
+                            globalGroups: self.globalHooks?[event],
+                            projectGroups: self.projectHooks?[event],
+                            localGroups: self.localHooks?[event]
                         )
                     }
                 }
@@ -674,9 +736,9 @@ struct HooksTabView: View {
     // MARK: Private
 
     private var allHooksEmpty: Bool {
-        (globalHooks?.isEmpty ?? true) &&
-            (projectHooks?.isEmpty ?? true) &&
-            (localHooks?.isEmpty ?? true)
+        (self.globalHooks?.isEmpty ?? true) &&
+            (self.projectHooks?.isEmpty ?? true) &&
+            (self.localHooks?.isEmpty ?? true)
     }
 
     private var allHookEvents: [String] {
@@ -706,7 +768,7 @@ struct HookEventSection: View {
     var body: some View {
         GroupBox {
             VStack(alignment: .leading, spacing: 8) {
-                Text(event)
+                Text(self.event)
                     .font(.headline)
 
                 // Global hooks
@@ -751,7 +813,7 @@ struct HookGroupRow: View {
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
-                SourceBadge(source: source)
+                SourceBadge(source: self.source)
             }
 
             if let hooks = group.hooks {

--- a/Fig/Sources/Views/ConfigTabViews.swift
+++ b/Fig/Sources/Views/ConfigTabViews.swift
@@ -519,6 +519,19 @@ struct MCPServerCard: View {
                     }
 
                     SourceBadge(source: source)
+
+                    if hasExpandableContent {
+                        Button {
+                            withAnimation {
+                                isExpanded.toggle()
+                            }
+                        } label: {
+                            Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                                .font(.caption)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel(isExpanded ? "Collapse \(name) details" : "Expand \(name) details")
+                    }
                 }
 
                 // Summary line
@@ -581,6 +594,25 @@ struct MCPServerCard: View {
     }
 
     // MARK: Private
+
+    @State private var isExpanded = false
+
+    private var hasExpandableContent: Bool {
+        if server.isHTTP {
+            return server.headers?.isEmpty == false
+        } else {
+            return server.env?.isEmpty == false
+        }
+    }
+
+    private func maskSensitiveValue(key: String, value: String) -> String {
+        let sensitivePatterns = ["token", "key", "secret", "password", "credential", "api", "authorization"]
+        let lowercaseKey = key.lowercased()
+        if sensitivePatterns.contains(where: { lowercaseKey.contains($0) }) {
+            return String(repeating: "\u{2022}", count: min(value.count, 20))
+        }
+        return value
+    }
 
     private func copyToClipboard() {
         let encoder = JSONEncoder()

--- a/Fig/Sources/Views/ConfigTabViews.swift
+++ b/Fig/Sources/Views/ConfigTabViews.swift
@@ -345,19 +345,48 @@ struct MCPServersTabView: View {
     var onEdit: ((String, MCPServer, ConfigSource) -> Void)?
     var onDelete: ((String, ConfigSource) -> Void)?
     var onCopy: ((String, MCPServer) -> Void)?
+    var onCopyAll: (() -> Void)?
+    var onPasteServers: (() -> Void)?
+
+    // MARK: Internal
+
+    var hasToolbar: Bool {
+        onAdd != nil || onCopyAll != nil || onPasteServers != nil
+    }
 
     var body: some View {
         VStack(spacing: 0) {
             // Toolbar
-            if onAdd != nil {
+            if hasToolbar {
                 HStack {
-                    Spacer()
-                    Button {
-                        onAdd?()
-                    } label: {
-                        Label("Add Server", systemImage: "plus")
+                    if onPasteServers != nil {
+                        Button {
+                            onPasteServers?()
+                        } label: {
+                            Label("Import from JSON", systemImage: "doc.on.clipboard")
+                        }
+                        .buttonStyle(.bordered)
                     }
-                    .buttonStyle(.bordered)
+
+                    Spacer()
+
+                    if onCopyAll != nil, !servers.isEmpty {
+                        Button {
+                            onCopyAll?()
+                        } label: {
+                            Label("Copy All as JSON", systemImage: "doc.on.doc")
+                        }
+                        .buttonStyle(.bordered)
+                    }
+
+                    if onAdd != nil {
+                        Button {
+                            onAdd?()
+                        } label: {
+                            Label("Add Server", systemImage: "plus")
+                        }
+                        .buttonStyle(.bordered)
+                    }
                 }
                 .padding(.horizontal)
                 .padding(.vertical, 8)

--- a/Fig/Sources/Views/EffectiveConfigView.swift
+++ b/Fig/Sources/Views/EffectiveConfigView.swift
@@ -16,12 +16,12 @@ struct EffectiveConfigView: View {
             HStack {
                 Spacer()
 
-                Toggle("View as JSON", isOn: $showJSON)
+                Toggle("View as JSON", isOn: self.$showJSON)
                     .toggleStyle(.switch)
                     .controlSize(.small)
 
                 Button {
-                    exportToClipboard()
+                    self.exportToClipboard()
                 } label: {
                     Label("Copy to Clipboard", systemImage: "doc.on.clipboard")
                 }
@@ -33,12 +33,12 @@ struct EffectiveConfigView: View {
 
             Divider()
 
-            if showJSON {
-                EffectiveConfigJSONView(mergedSettings: mergedSettings)
+            if self.showJSON {
+                EffectiveConfigJSONView(mergedSettings: self.mergedSettings)
             } else {
                 EffectiveConfigStructuredView(
-                    mergedSettings: mergedSettings,
-                    envOverrides: envOverrides
+                    mergedSettings: self.mergedSettings,
+                    envOverrides: self.envOverrides
                 )
             }
         }
@@ -49,7 +49,7 @@ struct EffectiveConfigView: View {
     @State private var showJSON = false
 
     private func exportToClipboard() {
-        let json = EffectiveConfigSerializer.toJSON(mergedSettings)
+        let json = EffectiveConfigSerializer.toJSON(self.mergedSettings)
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(json, forType: .string)
         NotificationManager.shared.showSuccess(
@@ -71,11 +71,11 @@ struct EffectiveConfigStructuredView: View {
             VStack(alignment: .leading, spacing: 20) {
                 SourceLegend()
 
-                EffectivePermissionsSection(permissions: mergedSettings.permissions)
-                EffectiveEnvSection(env: mergedSettings.env, overrides: envOverrides)
-                EffectiveHooksSection(hooks: mergedSettings.hooks)
-                EffectiveDisallowedToolsSection(tools: mergedSettings.disallowedTools)
-                EffectiveAttributionSection(attribution: mergedSettings.attribution)
+                EffectivePermissionsSection(permissions: self.mergedSettings.permissions)
+                EffectiveEnvSection(env: self.mergedSettings.env, overrides: self.envOverrides)
+                EffectiveHooksSection(hooks: self.mergedSettings.hooks)
+                EffectiveDisallowedToolsSection(tools: self.mergedSettings.disallowedTools)
+                EffectiveAttributionSection(attribution: self.mergedSettings.attribution)
 
                 Spacer()
             }
@@ -91,7 +91,7 @@ struct EffectiveConfigJSONView: View {
     let mergedSettings: MergedSettings
 
     var body: some View {
-        let jsonString = EffectiveConfigSerializer.toJSON(mergedSettings)
+        let jsonString = EffectiveConfigSerializer.toJSON(self.mergedSettings)
         ScrollView {
             Text(jsonString)
                 .font(.system(.body, design: .monospaced))
@@ -111,19 +111,19 @@ struct EffectivePermissionsSection: View {
 
     var body: some View {
         GroupBox("Permissions") {
-            if permissions.allow.isEmpty, permissions.deny.isEmpty {
+            if self.permissions.allow.isEmpty, self.permissions.deny.isEmpty {
                 Text("No permission rules configured.")
                     .foregroundStyle(.secondary)
                     .padding(.vertical, 8)
             } else {
                 VStack(alignment: .leading, spacing: 8) {
-                    if !permissions.allow.isEmpty {
+                    if !self.permissions.allow.isEmpty {
                         Label("Allow", systemImage: "checkmark.circle.fill")
                             .font(.subheadline)
                             .fontWeight(.medium)
                             .foregroundStyle(.green)
 
-                        ForEach(Array(permissions.allow.enumerated()), id: \.offset) { _, entry in
+                        ForEach(Array(self.permissions.allow.enumerated()), id: \.offset) { _, entry in
                             EffectiveRuleRow(
                                 rule: entry.value,
                                 source: entry.source,
@@ -133,17 +133,17 @@ struct EffectivePermissionsSection: View {
                         }
                     }
 
-                    if !permissions.allow.isEmpty, !permissions.deny.isEmpty {
+                    if !self.permissions.allow.isEmpty, !self.permissions.deny.isEmpty {
                         Divider()
                     }
 
-                    if !permissions.deny.isEmpty {
+                    if !self.permissions.deny.isEmpty {
                         Label("Deny", systemImage: "xmark.circle.fill")
                             .font(.subheadline)
                             .fontWeight(.medium)
                             .foregroundStyle(.red)
 
-                        ForEach(Array(permissions.deny.enumerated()), id: \.offset) { _, entry in
+                        ForEach(Array(self.permissions.deny.enumerated()), id: \.offset) { _, entry in
                             EffectiveRuleRow(
                                 rule: entry.value,
                                 source: entry.source,
@@ -168,19 +168,19 @@ struct EffectiveEnvSection: View {
 
     var body: some View {
         GroupBox("Environment Variables") {
-            if env.isEmpty {
+            if self.env.isEmpty {
                 Text("No environment variables configured.")
                     .foregroundStyle(.secondary)
                     .padding(.vertical, 8)
             } else {
                 VStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(env.keys.sorted().enumerated()), id: \.offset) { index, key in
+                    ForEach(Array(self.env.keys.sorted().enumerated()), id: \.offset) { index, key in
                         if index > 0 {
                             Divider()
                         }
 
-                        let entry = env[key]!
-                        let keyOverrides = overrides[key]
+                        let entry = self.env[key]!
+                        let keyOverrides = self.overrides[key]
 
                         EffectiveEnvRow(
                             key: key,
@@ -204,13 +204,13 @@ struct EffectiveHooksSection: View {
 
     var body: some View {
         GroupBox("Hooks") {
-            if hooks.eventNames.isEmpty {
+            if self.hooks.eventNames.isEmpty {
                 Text("No hooks configured.")
                     .foregroundStyle(.secondary)
                     .padding(.vertical, 8)
             } else {
                 VStack(alignment: .leading, spacing: 12) {
-                    ForEach(hooks.eventNames, id: \.self) { event in
+                    ForEach(self.hooks.eventNames, id: \.self) { event in
                         if let groups = hooks.groups(for: event) {
                             EffectiveHookEventView(event: event, groups: groups)
                         }
@@ -231,11 +231,11 @@ struct EffectiveHookEventView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(event)
+            Text(self.event)
                 .font(.subheadline)
                 .fontWeight(.medium)
 
-            ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
+            ForEach(Array(self.groups.enumerated()), id: \.offset) { _, group in
                 HStack {
                     VStack(alignment: .leading, spacing: 2) {
                         if let matcher = group.value.matcher {
@@ -274,13 +274,13 @@ struct EffectiveDisallowedToolsSection: View {
 
     var body: some View {
         GroupBox("Disallowed Tools") {
-            if tools.isEmpty {
+            if self.tools.isEmpty {
                 Text("No tools are disallowed.")
                     .foregroundStyle(.secondary)
                     .padding(.vertical, 8)
             } else {
                 VStack(alignment: .leading, spacing: 4) {
-                    ForEach(Array(tools.enumerated()), id: \.offset) { _, entry in
+                    ForEach(Array(self.tools.enumerated()), id: \.offset) { _, entry in
                         HStack {
                             Image(systemName: "xmark.circle.fill")
                                 .foregroundStyle(.red)
@@ -347,15 +347,15 @@ struct EffectiveRuleRow: View {
 
     var body: some View {
         HStack {
-            Image(systemName: icon)
-                .foregroundStyle(iconColor)
+            Image(systemName: self.icon)
+                .foregroundStyle(self.iconColor)
                 .frame(width: 20)
-            Text(rule)
+            Text(self.rule)
                 .font(.system(.body, design: .monospaced))
                 .lineLimit(1)
                 .truncationMode(.middle)
             Spacer()
-            SourceBadge(source: source)
+            SourceBadge(source: self.source)
         }
         .padding(.vertical, 2)
     }
@@ -375,21 +375,21 @@ struct EffectiveEnvRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             EffectiveEnvValueRow(
-                key: key,
-                value: effectiveValue,
-                source: effectiveSource,
-                isSensitive: isSensitive,
-                isValueVisible: $isValueVisible
+                key: self.key,
+                value: self.effectiveValue,
+                source: self.effectiveSource,
+                isSensitive: self.isSensitive,
+                isValueVisible: self.$isValueVisible
             )
 
-            if !overriddenEntries.isEmpty {
-                ForEach(Array(overriddenEntries.enumerated()), id: \.offset) { _, entry in
+            if !self.overriddenEntries.isEmpty {
+                ForEach(Array(self.overriddenEntries.enumerated()), id: \.offset) { _, entry in
                     EffectiveEnvOverriddenRow(
-                        key: key,
+                        key: self.key,
                         value: entry.value,
                         source: entry.source,
-                        isSensitive: isSensitive,
-                        isValueVisible: isValueVisible
+                        isSensitive: self.isSensitive,
+                        isValueVisible: self.isValueVisible
                     )
                 }
             }
@@ -403,7 +403,7 @@ struct EffectiveEnvRow: View {
 
     private var isSensitive: Bool {
         let sensitivePatterns = ["token", "key", "secret", "password", "credential", "api"]
-        let lowercaseKey = key.lowercased()
+        let lowercaseKey = self.key.lowercased()
         return sensitivePatterns.contains { lowercaseKey.contains($0) }
     }
 }
@@ -416,11 +416,12 @@ struct EffectiveEnvValueRow: View {
     let value: String
     let source: ConfigSource
     let isSensitive: Bool
+
     @Binding var isValueVisible: Bool
 
     var body: some View {
         HStack(alignment: .top) {
-            Text(key)
+            Text(self.key)
                 .font(.system(.body, design: .monospaced))
                 .fontWeight(.medium)
                 .frame(minWidth: 200, alignment: .leading)
@@ -429,29 +430,29 @@ struct EffectiveEnvValueRow: View {
                 .foregroundStyle(.secondary)
 
             Group {
-                if isValueVisible || !isSensitive {
-                    Text(value)
+                if self.isValueVisible || !self.isSensitive {
+                    Text(self.value)
                         .font(.system(.body, design: .monospaced))
                         .lineLimit(2)
                         .truncationMode(.middle)
                 } else {
-                    Text(String(repeating: "\u{2022}", count: min(value.count, 20)))
+                    Text(String(repeating: "\u{2022}", count: min(self.value.count, 20)))
                         .font(.system(.body, design: .monospaced))
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            if isSensitive {
+            if self.isSensitive {
                 Button {
-                    isValueVisible.toggle()
+                    self.isValueVisible.toggle()
                 } label: {
-                    Image(systemName: isValueVisible ? "eye.slash" : "eye")
+                    Image(systemName: self.isValueVisible ? "eye.slash" : "eye")
                         .font(.caption)
                 }
                 .buttonStyle(.plain)
             }
 
-            SourceBadge(source: source)
+            SourceBadge(source: self.source)
         }
     }
 }
@@ -468,7 +469,7 @@ struct EffectiveEnvOverriddenRow: View {
 
     var body: some View {
         HStack(alignment: .top) {
-            Text(key)
+            Text(self.key)
                 .font(.system(.caption, design: .monospaced))
                 .strikethrough()
                 .foregroundStyle(.secondary)
@@ -479,14 +480,14 @@ struct EffectiveEnvOverriddenRow: View {
                 .font(.caption)
 
             Group {
-                if isValueVisible || !isSensitive {
-                    Text(value)
+                if self.isValueVisible || !self.isSensitive {
+                    Text(self.value)
                         .font(.system(.caption, design: .monospaced))
                         .strikethrough()
                         .lineLimit(1)
                         .truncationMode(.middle)
                 } else {
-                    Text(String(repeating: "\u{2022}", count: min(value.count, 20)))
+                    Text(String(repeating: "\u{2022}", count: min(self.value.count, 20)))
                         .font(.system(.caption, design: .monospaced))
                         .strikethrough()
                 }
@@ -499,7 +500,7 @@ struct EffectiveEnvOverriddenRow: View {
                 .foregroundStyle(.orange)
                 .italic()
 
-            SourceBadge(source: source)
+            SourceBadge(source: self.source)
         }
         .padding(.leading, 8)
     }
@@ -509,19 +510,25 @@ struct EffectiveEnvOverriddenRow: View {
 
 /// Serializes merged settings to JSON format.
 enum EffectiveConfigSerializer {
+    // MARK: Internal
+
     static func toJSON(_ settings: MergedSettings) -> String {
         var result: [String: Any] = [:]
 
-        result["permissions"] = permissionsDict(settings.permissions)
-        result["env"] = envDict(settings)
-        result["hooks"] = hooksDict(settings.hooks)
-        result["disallowedTools"] = toolsArray(settings)
-        result["attribution"] = attributionDict(settings.attribution)
+        result["permissions"] = self.permissionsDict(settings.permissions)
+        result["env"] = self.envDict(settings)
+        result["hooks"] = self.hooksDict(settings.hooks)
+        result["disallowedTools"] = self.toolsArray(settings)
+        result["attribution"] = self.attributionDict(settings.attribution)
 
         // Remove nil/empty entries
         result = result.compactMapValues { value in
-            if let dict = value as? [String: Any], dict.isEmpty { return nil }
-            if let arr = value as? [Any], arr.isEmpty { return nil }
+            if let dict = value as? [String: Any], dict.isEmpty {
+                return nil
+            }
+            if let arr = value as? [Any], arr.isEmpty {
+                return nil
+            }
             return value
         }
 
@@ -542,8 +549,12 @@ enum EffectiveConfigSerializer {
         var perms: [String: Any] = [:]
         let allow = permissions.allowPatterns
         let deny = permissions.denyPatterns
-        if !allow.isEmpty { perms["allow"] = allow }
-        if !deny.isEmpty { perms["deny"] = deny }
+        if !allow.isEmpty {
+            perms["allow"] = allow
+        }
+        if !deny.isEmpty {
+            perms["deny"] = deny
+        }
         return perms.isEmpty ? nil : perms
     }
 
@@ -555,15 +566,23 @@ enum EffectiveConfigSerializer {
     private static func hooksDict(_ hooks: MergedHooks) -> [String: Any]? {
         var dict: [String: [[String: Any]]] = [:]
         for event in hooks.eventNames {
-            guard let groups = hooks.groups(for: event) else { continue }
+            guard let groups = hooks.groups(for: event) else {
+                continue
+            }
             dict[event] = groups.map { group in
                 var groupDict: [String: Any] = [:]
-                if let matcher = group.value.matcher { groupDict["matcher"] = matcher }
+                if let matcher = group.value.matcher {
+                    groupDict["matcher"] = matcher
+                }
                 if let hookDefs = group.value.hooks {
                     groupDict["hooks"] = hookDefs.map { hook in
                         var hookDict: [String: Any] = [:]
-                        if let type = hook.type { hookDict["type"] = type }
-                        if let command = hook.command { hookDict["command"] = command }
+                        if let type = hook.type {
+                            hookDict["type"] = type
+                        }
+                        if let command = hook.command {
+                            hookDict["command"] = command
+                        }
                         return hookDict
                     }
                 }
@@ -579,10 +598,16 @@ enum EffectiveConfigSerializer {
     }
 
     private static func attributionDict(_ attribution: MergedValue<Attribution>?) -> [String: Any]? {
-        guard let attr = attribution else { return nil }
+        guard let attr = attribution else {
+            return nil
+        }
         var dict: [String: Any] = [:]
-        if let commits = attr.value.commits { dict["commits"] = commits }
-        if let prs = attr.value.pullRequests { dict["pullRequests"] = prs }
+        if let commits = attr.value.commits {
+            dict["commits"] = commits
+        }
+        if let prs = attr.value.pullRequests {
+            dict["pullRequests"] = prs
+        }
         return dict.isEmpty ? nil : dict
     }
 }
@@ -593,18 +618,18 @@ enum EffectiveConfigSerializer {
             permissions: MergedPermissions(
                 allow: [
                     MergedValue(value: "Bash(npm run *)", source: .global),
-                    MergedValue(value: "Read(src/**)", source: .projectShared)
+                    MergedValue(value: "Read(src/**)", source: .projectShared),
                 ],
                 deny: [
-                    MergedValue(value: "Read(.env)", source: .projectLocal)
+                    MergedValue(value: "Read(.env)", source: .projectLocal),
                 ]
             ),
             env: [
                 "CLAUDE_CODE_MAX_OUTPUT_TOKENS": MergedValue(value: "16384", source: .projectLocal),
-                "ANTHROPIC_MODEL": MergedValue(value: "claude-sonnet-4-20250514", source: .global)
+                "ANTHROPIC_MODEL": MergedValue(value: "claude-sonnet-4-20250514", source: .global),
             ],
             disallowedTools: [
-                MergedValue(value: "WebFetch", source: .projectShared)
+                MergedValue(value: "WebFetch", source: .projectShared),
             ],
             attribution: MergedValue(
                 value: Attribution(commits: true, pullRequests: false),
@@ -614,8 +639,8 @@ enum EffectiveConfigSerializer {
         envOverrides: [
             "CLAUDE_CODE_MAX_OUTPUT_TOKENS": [
                 ("8192", .global),
-                ("16384", .projectLocal)
-            ]
+                ("16384", .projectLocal),
+            ],
         ]
     )
     .padding()

--- a/Fig/Sources/Views/EnvironmentEditorViews.swift
+++ b/Fig/Sources/Views/EnvironmentEditorViews.swift
@@ -13,14 +13,14 @@ struct EnvironmentVariableEditorView: View {
             VStack(alignment: .leading, spacing: 16) {
                 // Target selector and add button
                 HStack {
-                    if !viewModel.isGlobalMode {
-                        EditingTargetPicker(selection: $viewModel.editingTarget)
+                    if !self.viewModel.isGlobalMode {
+                        EditingTargetPicker(selection: self.$viewModel.editingTarget)
                     }
 
                     Spacer()
 
                     Button {
-                        showingAddVariable = true
+                        self.showingAddVariable = true
                     } label: {
                         Label("Add Variable", systemImage: "plus")
                     }
@@ -32,9 +32,9 @@ struct EnvironmentVariableEditorView: View {
                         ForEach(KnownEnvironmentVariable.allVariables) { variable in
                             KnownVariableRow(
                                 variable: variable,
-                                isAdded: viewModel.environmentVariables.contains { $0.key == variable.name }
+                                isAdded: self.viewModel.environmentVariables.contains { $0.key == variable.name }
                             ) {
-                                showingAddVariable = true
+                                self.showingAddVariable = true
                             }
                         }
                     }
@@ -71,31 +71,32 @@ struct EnvironmentVariableEditorView: View {
 
                         Divider()
 
-                        if viewModel.environmentVariables.isEmpty {
+                        if self.viewModel.environmentVariables.isEmpty {
                             Text("No environment variables configured.")
                                 .foregroundStyle(.secondary)
                                 .padding(.vertical, 16)
                                 .frame(maxWidth: .infinity, alignment: .center)
                         } else {
-                            ForEach(viewModel.environmentVariables) { envVar in
+                            ForEach(self.viewModel.environmentVariables) { envVar in
                                 EditableEnvironmentVariableRow(
                                     envVar: envVar,
                                     description: KnownEnvironmentVariable.description(for: envVar.key),
                                     onUpdate: { newKey, newValue in
-                                        viewModel.updateEnvironmentVariable(
+                                        self.viewModel.updateEnvironmentVariable(
                                             envVar,
                                             newKey: newKey,
                                             newValue: newValue
                                         )
                                     },
                                     onDelete: {
-                                        viewModel.removeEnvironmentVariable(envVar)
+                                        self.viewModel.removeEnvironmentVariable(envVar)
                                     },
                                     isDuplicateKey: { key in
-                                        key != envVar.key && viewModel.environmentVariables.contains { $0.key == key }
+                                        key != envVar.key && self.viewModel.environmentVariables
+                                            .contains { $0.key == key }
                                     }
                                 )
-                                if envVar.id != viewModel.environmentVariables.last?.id {
+                                if envVar.id != self.viewModel.environmentVariables.last?.id {
                                     Divider()
                                 }
                             }
@@ -108,11 +109,11 @@ struct EnvironmentVariableEditorView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .sheet(isPresented: $showingAddVariable) {
+        .sheet(isPresented: self.$showingAddVariable) {
             AddEnvironmentVariableSheet { key, value in
-                viewModel.addEnvironmentVariable(key: key, value: value)
+                self.viewModel.addEnvironmentVariable(key: key, value: value)
             } isDuplicateKey: { key in
-                viewModel.environmentVariables.contains { $0.key == key }
+                self.viewModel.environmentVariables.contains { $0.key == key }
             }
         }
     }
@@ -133,20 +134,20 @@ struct KnownVariableRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             HStack {
-                Text(variable.name)
+                Text(self.variable.name)
                     .font(.system(.caption, design: .monospaced))
                     .fontWeight(.medium)
 
                 Button {
-                    onAddTapped()
+                    self.onAddTapped()
                 } label: {
                     Image(systemName: "plus.circle")
                         .font(.caption)
                 }
                 .buttonStyle(.plain)
-                .disabled(isAdded)
+                .disabled(self.isAdded)
             }
-            Text(variable.description)
+            Text(self.variable.description)
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
@@ -167,25 +168,25 @@ struct EditableEnvironmentVariableRow: View {
 
     var body: some View {
         HStack(alignment: .top) {
-            if isEditing {
-                editingContent
+            if self.isEditing {
+                self.editingContent
             } else {
-                displayContent
+                self.displayContent
             }
         }
         .padding(.vertical, 8)
         .padding(.horizontal, 8)
         .confirmationDialog(
             "Delete Variable",
-            isPresented: $showingDeleteConfirmation,
+            isPresented: self.$showingDeleteConfirmation,
             titleVisibility: .visible
         ) {
             Button("Delete", role: .destructive) {
-                onDelete()
+                self.onDelete()
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("Are you sure you want to delete \(envVar.key)?")
+            Text("Are you sure you want to delete \(self.envVar.key)?")
         }
     }
 
@@ -199,33 +200,33 @@ struct EditableEnvironmentVariableRow: View {
 
     private var isSensitive: Bool {
         let sensitivePatterns = ["token", "key", "secret", "password", "credential", "api"]
-        let lowercaseKey = envVar.key.lowercased()
+        let lowercaseKey = self.envVar.key.lowercased()
         return sensitivePatterns.contains { lowercaseKey.contains($0) }
     }
 
     private var canSave: Bool {
-        !editedKey.isEmpty && !isDuplicateKey(editedKey)
+        !self.editedKey.isEmpty && !self.isDuplicateKey(self.editedKey)
     }
 
     @ViewBuilder private var editingContent: some View {
-        TextField("Key", text: $editedKey)
+        TextField("Key", text: self.$editedKey)
             .textFieldStyle(.roundedBorder)
             .font(.system(.body, design: .monospaced))
             .frame(minWidth: 200, alignment: .leading)
 
-        TextField("Value", text: $editedValue)
+        TextField("Value", text: self.$editedValue)
             .textFieldStyle(.roundedBorder)
             .font(.system(.body, design: .monospaced))
             .frame(maxWidth: .infinity)
 
         HStack(spacing: 4) {
             Button("Save") {
-                saveEdit()
+                self.saveEdit()
             }
-            .disabled(!canSave)
+            .disabled(!self.canSave)
 
             Button("Cancel") {
-                cancelEdit()
+                self.cancelEdit()
             }
         }
         .frame(width: 120)
@@ -233,7 +234,7 @@ struct EditableEnvironmentVariableRow: View {
 
     @ViewBuilder private var displayContent: some View {
         VStack(alignment: .leading, spacing: 2) {
-            Text(envVar.key)
+            Text(self.envVar.key)
                 .font(.system(.body, design: .monospaced))
                 .fontWeight(.medium)
             if let description {
@@ -248,11 +249,11 @@ struct EditableEnvironmentVariableRow: View {
             .foregroundStyle(.secondary)
 
         Group {
-            if isValueVisible || !isSensitive {
-                Text(envVar.value)
+            if self.isValueVisible || !self.isSensitive {
+                Text(self.envVar.value)
                     .font(.system(.body, design: .monospaced))
             } else {
-                Text(String(repeating: "\u{2022}", count: min(envVar.value.count, 20)))
+                Text(String(repeating: "\u{2022}", count: min(self.envVar.value.count, 20)))
                     .font(.system(.body, design: .monospaced))
             }
         }
@@ -260,18 +261,18 @@ struct EditableEnvironmentVariableRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
 
         HStack(spacing: 8) {
-            if isSensitive {
+            if self.isSensitive {
                 Button {
-                    isValueVisible.toggle()
+                    self.isValueVisible.toggle()
                 } label: {
-                    Image(systemName: isValueVisible ? "eye.slash" : "eye")
+                    Image(systemName: self.isValueVisible ? "eye.slash" : "eye")
                         .font(.caption)
                 }
                 .buttonStyle(.plain)
             }
 
             Button {
-                startEditing()
+                self.startEditing()
             } label: {
                 Image(systemName: "pencil")
                     .font(.caption)
@@ -279,7 +280,7 @@ struct EditableEnvironmentVariableRow: View {
             .buttonStyle(.plain)
 
             Button {
-                showingDeleteConfirmation = true
+                self.showingDeleteConfirmation = true
             } label: {
                 Image(systemName: "trash")
                     .font(.caption)
@@ -291,21 +292,23 @@ struct EditableEnvironmentVariableRow: View {
     }
 
     private func startEditing() {
-        editedKey = envVar.key
-        editedValue = envVar.value
-        isEditing = true
+        self.editedKey = self.envVar.key
+        self.editedValue = self.envVar.value
+        self.isEditing = true
     }
 
     private func saveEdit() {
-        guard canSave else { return }
-        onUpdate(editedKey, editedValue)
-        isEditing = false
+        guard self.canSave else {
+            return
+        }
+        self.onUpdate(self.editedKey, self.editedValue)
+        self.isEditing = false
     }
 
     private func cancelEdit() {
-        isEditing = false
-        editedKey = envVar.key
-        editedValue = envVar.value
+        self.isEditing = false
+        self.editedKey = self.envVar.key
+        self.editedValue = self.envVar.value
     }
 }
 
@@ -337,13 +340,13 @@ struct AddEnvironmentVariableSheet: View {
                 Text("Key")
                     .font(.headline)
 
-                TextField("VARIABLE_NAME", text: $key)
+                TextField("VARIABLE_NAME", text: self.$key)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
 
                 // Autocomplete suggestions
-                if !key.isEmpty {
-                    autocompleteView
+                if !self.key.isEmpty {
+                    self.autocompleteView
                 }
 
                 // Show description for known variables
@@ -359,7 +362,7 @@ struct AddEnvironmentVariableSheet: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Value")
                     .font(.headline)
-                TextField("value", text: $value)
+                TextField("value", text: self.$value)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
             }
@@ -380,18 +383,18 @@ struct AddEnvironmentVariableSheet: View {
             // Buttons
             HStack {
                 Button("Cancel") {
-                    dismiss()
+                    self.dismiss()
                 }
                 .keyboardShortcut(.cancelAction)
 
                 Spacer()
 
                 Button("Add Variable") {
-                    onAdd(key, value)
-                    dismiss()
+                    self.onAdd(self.key, self.value)
+                    self.dismiss()
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(!isValid)
+                .disabled(!self.isValid)
             }
         }
         .padding()
@@ -406,16 +409,33 @@ struct AddEnvironmentVariableSheet: View {
     @State private var key = ""
     @State private var value = ""
 
+    private var validationError: String? {
+        if self.key.isEmpty {
+            return nil // Don't show error until they try to submit
+        }
+        if self.isDuplicateKey(self.key) {
+            return "A variable with this key already exists"
+        }
+        if self.key.contains(" ") {
+            return "Key cannot contain spaces"
+        }
+        return nil
+    }
+
+    private var isValid: Bool {
+        !self.key.isEmpty && !self.isDuplicateKey(self.key) && !self.key.contains(" ")
+    }
+
     @ViewBuilder private var autocompleteView: some View {
         let suggestions = KnownEnvironmentVariable.allVariables.filter {
-            $0.name.localizedCaseInsensitiveContains(key)
+            $0.name.localizedCaseInsensitiveContains(self.key)
         }
         if !suggestions.isEmpty {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 8) {
                     ForEach(suggestions) { variable in
                         Button {
-                            key = variable.name
+                            self.key = variable.name
                         } label: {
                             Text(variable.name)
                                 .font(.caption)
@@ -429,30 +449,13 @@ struct AddEnvironmentVariableSheet: View {
             }
         }
     }
-
-    private var validationError: String? {
-        if key.isEmpty {
-            return nil // Don't show error until they try to submit
-        }
-        if isDuplicateKey(key) {
-            return "A variable with this key already exists"
-        }
-        if key.contains(" ") {
-            return "Key cannot contain spaces"
-        }
-        return nil
-    }
-
-    private var isValid: Bool {
-        !key.isEmpty && !isDuplicateKey(key) && !key.contains(" ")
-    }
 }
 
 #Preview("Environment Variable Editor") {
     let viewModel = SettingsEditorViewModel(projectPath: "/Users/test/project")
     viewModel.environmentVariables = [
         EditableEnvironmentVariable(key: "CLAUDE_CODE_MAX_OUTPUT_TOKENS", value: "16384"),
-        EditableEnvironmentVariable(key: "API_KEY", value: "sk-1234567890")
+        EditableEnvironmentVariable(key: "API_KEY", value: "sk-1234567890"),
     ]
 
     return EnvironmentVariableEditorView(viewModel: viewModel)

--- a/Fig/Sources/Views/HookEditorViews.swift
+++ b/Fig/Sources/Views/HookEditorViews.swift
@@ -13,8 +13,8 @@ struct HookEditorView: View {
             VStack(alignment: .leading, spacing: 16) {
                 // Target selector and templates
                 HStack {
-                    if !viewModel.isGlobalMode {
-                        EditingTargetPicker(selection: $viewModel.editingTarget)
+                    if !self.viewModel.isGlobalMode {
+                        EditingTargetPicker(selection: self.$viewModel.editingTarget)
                     }
 
                     Spacer()
@@ -22,7 +22,7 @@ struct HookEditorView: View {
                     Menu {
                         ForEach(HookTemplate.allTemplates) { template in
                             Button {
-                                viewModel.applyHookTemplate(template)
+                                self.viewModel.applyHookTemplate(template)
                             } label: {
                                 VStack(alignment: .leading) {
                                     Text(template.name)
@@ -41,18 +41,18 @@ struct HookEditorView: View {
                 ForEach(HookEvent.allCases) { event in
                     EditableHookEventSection(
                         event: event,
-                        groups: viewModel.hookGroups[event.rawValue] ?? [],
-                        viewModel: viewModel,
+                        groups: self.viewModel.hookGroups[event.rawValue] ?? [],
+                        viewModel: self.viewModel,
                         onAddGroup: {
-                            addingForEvent = event
-                            showingAddHookGroup = true
+                            self.addingForEvent = event
+                            self.showingAddHookGroup = true
                         }
                     )
                 }
 
                 // Show unrecognized hook events that exist in settings
                 // but aren't in the HookEvent enum (e.g., future event types)
-                let unrecognizedEvents = viewModel.hookGroups.keys
+                let unrecognizedEvents = self.viewModel.hookGroups.keys
                     .filter { key in !HookEvent.allCases.contains(where: { $0.rawValue == key }) }
                     .sorted()
 
@@ -69,7 +69,7 @@ struct HookEditorView: View {
                             .foregroundStyle(.secondary)
 
                             ForEach(unrecognizedEvents, id: \.self) { eventKey in
-                                let groupCount = viewModel.hookGroups[eventKey]?.count ?? 0
+                                let groupCount = self.viewModel.hookGroups[eventKey]?.count ?? 0
                                 HStack {
                                     Text(eventKey)
                                         .font(.system(.body, design: .monospaced))
@@ -92,10 +92,10 @@ struct HookEditorView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .sheet(isPresented: $showingAddHookGroup) {
-            AddHookGroupSheet(event: addingForEvent) { matcher, commands in
-                viewModel.addHookGroup(
-                    event: addingForEvent.rawValue,
+        .sheet(isPresented: self.$showingAddHookGroup) {
+            AddHookGroupSheet(event: self.addingForEvent) { matcher, commands in
+                self.viewModel.addHookGroup(
+                    event: self.addingForEvent.rawValue,
                     matcher: matcher,
                     commands: commands
                 )
@@ -113,46 +113,45 @@ struct HookEditorView: View {
 
 /// A section displaying hook groups for a specific lifecycle event.
 struct EditableHookEventSection: View {
-    // MARK: Internal
-
     let event: HookEvent
     let groups: [EditableHookGroup]
     @Bindable var viewModel: SettingsEditorViewModel
+
     let onAddGroup: () -> Void
 
     var body: some View {
         GroupBox {
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
-                    Label(event.displayName, systemImage: event.icon)
+                    Label(self.event.displayName, systemImage: self.event.icon)
                         .font(.headline)
 
                     Spacer()
 
                     Button {
-                        onAddGroup()
+                        self.onAddGroup()
                     } label: {
                         Label("Add Group", systemImage: "plus")
                     }
                     .buttonStyle(.borderless)
                 }
 
-                Text(event.description)
+                Text(self.event.description)
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                if groups.isEmpty {
+                if self.groups.isEmpty {
                     Text("No hooks configured.")
                         .foregroundStyle(.secondary)
                         .padding(.vertical, 8)
                 } else {
-                    ForEach(Array(groups.enumerated()), id: \.element.id) { index, group in
+                    ForEach(Array(self.groups.enumerated()), id: \.element.id) { index, group in
                         EditableHookGroupRow(
-                            event: event,
+                            event: self.event,
                             group: group,
                             groupIndex: index,
-                            groupCount: groups.count,
-                            viewModel: viewModel
+                            groupCount: self.groups.count,
+                            viewModel: self.viewModel
                         )
                     }
                 }
@@ -172,39 +171,40 @@ struct EditableHookGroupRow: View {
     let group: EditableHookGroup
     let groupIndex: Int
     let groupCount: Int
+
     @Bindable var viewModel: SettingsEditorViewModel
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             // Matcher row
             HStack {
-                if event.supportsMatcher {
-                    if isEditingMatcher {
-                        TextField("Matcher pattern", text: $editedMatcher)
+                if self.event.supportsMatcher {
+                    if self.isEditingMatcher {
+                        TextField("Matcher pattern", text: self.$editedMatcher)
                             .textFieldStyle(.roundedBorder)
                             .font(.system(.body, design: .monospaced))
                             .onSubmit {
-                                saveMatcher()
+                                self.saveMatcher()
                             }
 
                         Button("Save") {
-                            saveMatcher()
+                            self.saveMatcher()
                         }
 
                         Button("Cancel") {
-                            isEditingMatcher = false
-                            editedMatcher = group.matcher
+                            self.isEditingMatcher = false
+                            self.editedMatcher = self.group.matcher
                         }
                     } else {
                         Label(
-                            group.matcher.isEmpty ? "All tools" : group.matcher,
+                            self.group.matcher.isEmpty ? "All tools" : self.group.matcher,
                             systemImage: "target"
                         )
                         .font(.system(.body, design: .monospaced))
-                        .foregroundStyle(group.matcher.isEmpty ? .secondary : .primary)
+                        .foregroundStyle(self.group.matcher.isEmpty ? .secondary : .primary)
 
                         Button {
-                            startEditingMatcher()
+                            self.startEditingMatcher()
                         } label: {
                             Image(systemName: "pencil")
                                 .font(.caption)
@@ -220,11 +220,11 @@ struct EditableHookGroupRow: View {
                 Spacer()
 
                 // Reorder buttons
-                if groupCount > 1 {
+                if self.groupCount > 1 {
                     Button {
-                        viewModel.moveHookGroup(
-                            event: event.rawValue,
-                            from: groupIndex,
+                        self.viewModel.moveHookGroup(
+                            event: self.event.rawValue,
+                            from: self.groupIndex,
                             direction: -1
                         )
                     } label: {
@@ -232,13 +232,13 @@ struct EditableHookGroupRow: View {
                             .font(.caption)
                     }
                     .buttonStyle(.plain)
-                    .disabled(groupIndex == 0)
+                    .disabled(self.groupIndex == 0)
                     .help("Move up")
 
                     Button {
-                        viewModel.moveHookGroup(
-                            event: event.rawValue,
-                            from: groupIndex,
+                        self.viewModel.moveHookGroup(
+                            event: self.event.rawValue,
+                            from: self.groupIndex,
                             direction: 1
                         )
                     } label: {
@@ -246,13 +246,13 @@ struct EditableHookGroupRow: View {
                             .font(.caption)
                     }
                     .buttonStyle(.plain)
-                    .disabled(groupIndex == groupCount - 1)
+                    .disabled(self.groupIndex == self.groupCount - 1)
                     .help("Move down")
                 }
 
                 // Add command button
                 Button {
-                    showingAddCommand = true
+                    self.showingAddCommand = true
                 } label: {
                     Image(systemName: "plus.circle")
                         .font(.caption)
@@ -262,7 +262,7 @@ struct EditableHookGroupRow: View {
 
                 // Delete group button
                 Button {
-                    showingDeleteConfirmation = true
+                    self.showingDeleteConfirmation = true
                 } label: {
                     Image(systemName: "trash")
                         .font(.caption)
@@ -272,30 +272,30 @@ struct EditableHookGroupRow: View {
             }
 
             // Hook definitions (commands)
-            ForEach(Array(group.hooks.enumerated()), id: \.element.id) { hookIndex, hook in
+            ForEach(Array(self.group.hooks.enumerated()), id: \.element.id) { hookIndex, hook in
                 HookDefinitionRow(
                     hook: hook,
                     hookIndex: hookIndex,
-                    hookCount: group.hooks.count,
+                    hookCount: self.group.hooks.count,
                     onUpdate: { newCommand in
-                        viewModel.updateHookDefinition(
-                            event: event.rawValue,
-                            groupID: group.id,
+                        self.viewModel.updateHookDefinition(
+                            event: self.event.rawValue,
+                            groupID: self.group.id,
                             hook: hook,
                             newCommand: newCommand
                         )
                     },
                     onDelete: {
-                        viewModel.removeHookDefinition(
-                            event: event.rawValue,
-                            groupID: group.id,
+                        self.viewModel.removeHookDefinition(
+                            event: self.event.rawValue,
+                            groupID: self.group.id,
                             hook: hook
                         )
                     },
                     onMove: { direction in
-                        viewModel.moveHookDefinition(
-                            event: event.rawValue,
-                            groupID: group.id,
+                        self.viewModel.moveHookDefinition(
+                            event: self.event.rawValue,
+                            groupID: self.group.id,
                             from: hookIndex,
                             direction: direction
                         )
@@ -311,21 +311,21 @@ struct EditableHookGroupRow: View {
         )
         .confirmationDialog(
             "Delete Hook Group",
-            isPresented: $showingDeleteConfirmation,
+            isPresented: self.$showingDeleteConfirmation,
             titleVisibility: .visible
         ) {
             Button("Delete", role: .destructive) {
-                viewModel.removeHookGroup(event: event.rawValue, group: group)
+                self.viewModel.removeHookGroup(event: self.event.rawValue, group: self.group)
             }
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("Are you sure you want to delete this hook group?")
         }
-        .sheet(isPresented: $showingAddCommand) {
+        .sheet(isPresented: self.$showingAddCommand) {
             AddHookCommandSheet { command in
-                viewModel.addHookDefinition(
-                    event: event.rawValue,
-                    groupID: group.id,
+                self.viewModel.addHookDefinition(
+                    event: self.event.rawValue,
+                    groupID: self.group.id,
                     command: command
                 )
             }
@@ -340,17 +340,17 @@ struct EditableHookGroupRow: View {
     @State private var showingAddCommand = false
 
     private func startEditingMatcher() {
-        editedMatcher = group.matcher
-        isEditingMatcher = true
+        self.editedMatcher = self.group.matcher
+        self.isEditingMatcher = true
     }
 
     private func saveMatcher() {
-        viewModel.updateHookGroupMatcher(
-            event: event.rawValue,
-            group: group,
-            newMatcher: editedMatcher
+        self.viewModel.updateHookGroupMatcher(
+            event: self.event.rawValue,
+            group: self.group,
+            newMatcher: self.editedMatcher
         )
-        isEditingMatcher = false
+        self.isEditingMatcher = false
     }
 }
 
@@ -373,25 +373,25 @@ struct HookDefinitionRow: View {
                 .foregroundStyle(.blue)
                 .frame(width: 20)
 
-            if isEditing {
-                TextField("Command", text: $editedCommand)
+            if self.isEditing {
+                TextField("Command", text: self.$editedCommand)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
                     .onSubmit {
-                        saveEdit()
+                        self.saveEdit()
                     }
 
                 Button("Save") {
-                    saveEdit()
+                    self.saveEdit()
                 }
-                .disabled(editedCommand.isEmpty)
+                .disabled(self.editedCommand.isEmpty)
 
                 Button("Cancel") {
-                    isEditing = false
-                    editedCommand = hook.command
+                    self.isEditing = false
+                    self.editedCommand = self.hook.command
                 }
             } else {
-                Text(hook.command)
+                Text(self.hook.command)
                     .font(.system(.body, design: .monospaced))
                     .lineLimit(1)
                     .truncationMode(.middle)
@@ -399,29 +399,29 @@ struct HookDefinitionRow: View {
                 Spacer()
 
                 // Reorder buttons
-                if hookCount > 1 {
+                if self.hookCount > 1 {
                     Button {
-                        onMove(-1)
+                        self.onMove(-1)
                     } label: {
                         Image(systemName: "chevron.up")
                             .font(.caption2)
                     }
                     .buttonStyle(.plain)
-                    .disabled(hookIndex == 0)
+                    .disabled(self.hookIndex == 0)
 
                     Button {
-                        onMove(1)
+                        self.onMove(1)
                     } label: {
                         Image(systemName: "chevron.down")
                             .font(.caption2)
                     }
                     .buttonStyle(.plain)
-                    .disabled(hookIndex == hookCount - 1)
+                    .disabled(self.hookIndex == self.hookCount - 1)
                 }
 
                 Button {
-                    isEditing = true
-                    editedCommand = hook.command
+                    self.isEditing = true
+                    self.editedCommand = self.hook.command
                 } label: {
                     Image(systemName: "pencil")
                         .font(.caption)
@@ -429,7 +429,7 @@ struct HookDefinitionRow: View {
                 .buttonStyle(.plain)
 
                 Button {
-                    showingDeleteConfirmation = true
+                    self.showingDeleteConfirmation = true
                 } label: {
                     Image(systemName: "trash")
                         .font(.caption)
@@ -442,15 +442,15 @@ struct HookDefinitionRow: View {
         .padding(.leading, 20)
         .confirmationDialog(
             "Delete Command",
-            isPresented: $showingDeleteConfirmation,
+            isPresented: self.$showingDeleteConfirmation,
             titleVisibility: .visible
         ) {
             Button("Delete", role: .destructive) {
-                onDelete()
+                self.onDelete()
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("Are you sure you want to delete this command?\n\(hook.command)")
+            Text("Are you sure you want to delete this command?\n\(self.hook.command)")
         }
     }
 
@@ -461,9 +461,11 @@ struct HookDefinitionRow: View {
     @State private var showingDeleteConfirmation = false
 
     private func saveEdit() {
-        guard !editedCommand.isEmpty else { return }
-        onUpdate(editedCommand)
-        isEditing = false
+        guard !self.editedCommand.isEmpty else {
+            return
+        }
+        self.onUpdate(self.editedCommand)
+        self.isEditing = false
     }
 }
 
@@ -480,10 +482,10 @@ struct AddHookGroupSheet: View {
         VStack(alignment: .leading, spacing: 16) {
             // Header
             HStack {
-                Image(systemName: event.icon)
+                Image(systemName: self.event.icon)
                     .foregroundStyle(.blue)
                     .font(.title2)
-                Text("Add Hook Group \u{2014} \(event.displayName)")
+                Text("Add Hook Group \u{2014} \(self.event.displayName)")
                     .font(.title2)
                     .fontWeight(.semibold)
             }
@@ -491,11 +493,11 @@ struct AddHookGroupSheet: View {
             Divider()
 
             // Matcher input (if supported)
-            if event.supportsMatcher {
+            if self.event.supportsMatcher {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Matcher Pattern")
                         .font(.headline)
-                    TextField(event.matcherPlaceholder, text: $matcher)
+                    TextField(self.event.matcherPlaceholder, text: self.$matcher)
                         .textFieldStyle(.roundedBorder)
                         .font(.system(.body, design: .monospaced))
                     Text("Use tool name with optional glob pattern. Leave empty to match all.")
@@ -508,7 +510,7 @@ struct AddHookGroupSheet: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Command")
                     .font(.headline)
-                TextField("e.g., npm run lint, black $CLAUDE_FILE_PATH", text: $command)
+                TextField("e.g., npm run lint, black $CLAUDE_FILE_PATH", text: self.$command)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
                 Text("Shell command to run. You can add more commands after creation.")
@@ -523,19 +525,19 @@ struct AddHookGroupSheet: View {
                 HStack(spacing: 4) {
                     Text("When")
                         .foregroundStyle(.secondary)
-                    Text(event.displayName)
+                    Text(self.event.displayName)
                         .fontWeight(.medium)
-                    if event.supportsMatcher, !matcher.isEmpty {
+                    if self.event.supportsMatcher, !self.matcher.isEmpty {
                         Text("matches")
                             .foregroundStyle(.secondary)
-                        Text(matcher)
+                        Text(self.matcher)
                             .font(.system(.body, design: .monospaced))
                     }
                     Text("\u{2192}")
                         .foregroundStyle(.secondary)
                     Text("Run")
                         .foregroundStyle(.secondary)
-                    Text(command.isEmpty ? "..." : command)
+                    Text(self.command.isEmpty ? "..." : self.command)
                         .font(.system(.body, design: .monospaced))
                         .lineLimit(1)
                         .truncationMode(.tail)
@@ -550,18 +552,18 @@ struct AddHookGroupSheet: View {
             // Buttons
             HStack {
                 Button("Cancel") {
-                    dismiss()
+                    self.dismiss()
                 }
                 .keyboardShortcut(.cancelAction)
 
                 Spacer()
 
                 Button("Add Hook Group") {
-                    onAdd(matcher, [command])
-                    dismiss()
+                    self.onAdd(self.matcher, [self.command])
+                    self.dismiss()
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(command.isEmpty)
+                .disabled(self.command.isEmpty)
             }
         }
         .padding()
@@ -601,7 +603,7 @@ struct AddHookCommandSheet: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Command")
                     .font(.headline)
-                TextField("Shell command to execute", text: $command)
+                TextField("Shell command to execute", text: self.$command)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
             }
@@ -610,18 +612,18 @@ struct AddHookCommandSheet: View {
 
             HStack {
                 Button("Cancel") {
-                    dismiss()
+                    self.dismiss()
                 }
                 .keyboardShortcut(.cancelAction)
 
                 Spacer()
 
                 Button("Add Command") {
-                    onAdd(command)
-                    dismiss()
+                    self.onAdd(self.command)
+                    self.dismiss()
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(command.isEmpty)
+                .disabled(self.command.isEmpty)
             }
         }
         .padding()

--- a/Fig/Sources/Views/MCPHealthCheckButton.swift
+++ b/Fig/Sources/Views/MCPHealthCheckButton.swift
@@ -11,28 +11,24 @@ struct MCPHealthCheckButton: View {
 
     var body: some View {
         Button {
-            runHealthCheck()
+            self.runHealthCheck()
         } label: {
             HStack(spacing: 4) {
-                statusIcon
+                self.statusIcon
                 Text("Test")
                     .font(.caption2)
             }
         }
         .buttonStyle(.bordered)
         .controlSize(.small)
-        .disabled(isChecking)
-        .help(helpText)
-        .popover(isPresented: $showDetails) {
-            HealthCheckResultPopover(result: result)
+        .disabled(self.isChecking)
+        .help(self.helpText)
+        .popover(isPresented: self.$showDetails) {
+            HealthCheckResultPopover(result: self.result)
         }
     }
 
     // MARK: Private
-
-    @State private var state: CheckState = .idle
-    @State private var result: MCPHealthCheckResult?
-    @State private var showDetails = false
 
     private enum CheckState {
         case idle
@@ -40,12 +36,16 @@ struct MCPHealthCheckButton: View {
         case completed
     }
 
+    @State private var state: CheckState = .idle
+    @State private var result: MCPHealthCheckResult?
+    @State private var showDetails = false
+
     private var isChecking: Bool {
-        state == .checking
+        self.state == .checking
     }
 
     private var helpText: String {
-        switch state {
+        switch self.state {
         case .idle:
             "Test server connection"
         case .checking:
@@ -60,7 +60,7 @@ struct MCPHealthCheckButton: View {
     }
 
     @ViewBuilder private var statusIcon: some View {
-        switch state {
+        switch self.state {
         case .idle:
             Image(systemName: "play.circle")
                 .foregroundStyle(.secondary)
@@ -89,27 +89,27 @@ struct MCPHealthCheckButton: View {
     }
 
     private func runHealthCheck() {
-        if state == .completed, result != nil {
+        if self.state == .completed, self.result != nil {
             // Show details if we already have a result
-            showDetails = true
+            self.showDetails = true
             return
         }
 
-        state = .checking
-        result = nil
+        self.state = .checking
+        self.result = nil
 
         Task {
             let checkResult = await MCPHealthCheckService.shared.checkHealth(
-                name: serverName,
-                server: server
+                name: self.serverName,
+                server: self.server
             )
-            result = checkResult
-            state = .completed
+            self.result = checkResult
+            self.state = .completed
 
             // Show toast notification
             switch checkResult.status {
             case let .success(info):
-                let name = info?.serverName ?? serverName
+                let name = info?.serverName ?? self.serverName
                 NotificationManager.shared.showSuccess(
                     "Connected to \(name)",
                     message: String(format: "Response time: %.0fms", checkResult.duration * 1000)
@@ -133,6 +133,8 @@ struct MCPHealthCheckButton: View {
 
 /// Popover showing detailed health check results.
 struct HealthCheckResultPopover: View {
+    // MARK: Internal
+
     let result: MCPHealthCheckResult?
 
     var body: some View {
@@ -140,9 +142,9 @@ struct HealthCheckResultPopover: View {
             if let result {
                 // Status header
                 HStack {
-                    statusIcon(for: result)
+                    self.statusIcon(for: result)
                     VStack(alignment: .leading) {
-                        Text(statusTitle(for: result))
+                        Text(self.statusTitle(for: result))
                             .font(.headline)
                         Text(String(format: "%.0fms", result.duration * 1000))
                             .font(.caption)
@@ -205,6 +207,8 @@ struct HealthCheckResultPopover: View {
         .frame(minWidth: 250, maxWidth: 350)
     }
 
+    // MARK: Private
+
     @ViewBuilder
     private func statusIcon(for result: MCPHealthCheckResult) -> some View {
         switch result.status {
@@ -244,10 +248,10 @@ private struct HealthCheckDetailRow: View {
 
     var body: some View {
         HStack {
-            Text(label + ":")
+            Text(self.label + ":")
                 .font(.caption)
                 .foregroundStyle(.secondary)
-            Text(value)
+            Text(self.value)
                 .font(.caption)
                 .fontWeight(.medium)
         }

--- a/Fig/Sources/Views/MCPPasteSheet.swift
+++ b/Fig/Sources/Views/MCPPasteSheet.swift
@@ -1,0 +1,300 @@
+import SwiftUI
+
+// MARK: - MCPPasteSheet
+
+/// Sheet for importing MCP servers from pasted JSON.
+struct MCPPasteSheet: View {
+    // MARK: Internal
+
+    @Bindable var viewModel: MCPPasteViewModel
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    jsonInputSection
+                    previewSection
+                    destinationSection
+                    conflictSection
+
+                    if let result = viewModel.importResult {
+                        resultSection(result: result)
+                    }
+
+                    if let error = viewModel.errorMessage {
+                        errorSection(error: error)
+                    }
+                }
+                .padding()
+            }
+
+            Divider()
+
+            footer
+        }
+        .frame(width: 500, height: 550)
+    }
+
+    // MARK: Private
+
+    private var header: some View {
+        HStack {
+            Image(systemName: "doc.on.clipboard")
+                .font(.title2)
+                .foregroundStyle(.blue)
+
+            VStack(alignment: .leading) {
+                Text("Import MCP Servers")
+                    .font(.headline)
+                Text("Paste JSON configuration to add servers")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
+        .padding()
+    }
+
+    private var jsonInputSection: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Paste your MCP server JSON below:")
+                        .font(.subheadline)
+
+                    Spacer()
+
+                    Button {
+                        Task {
+                            await viewModel.loadFromClipboard()
+                        }
+                    } label: {
+                        Label("Paste from Clipboard", systemImage: "clipboard")
+                            .font(.caption)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+
+                TextEditor(text: $viewModel.jsonText)
+                    .font(.system(.caption, design: .monospaced))
+                    .frame(minHeight: 120, maxHeight: 150)
+                    .scrollContentBackground(.hidden)
+                    .padding(4)
+                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+
+                if let error = viewModel.parseError {
+                    HStack {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.red)
+                            .font(.caption)
+                        Text(error)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .padding(.vertical, 4)
+        } label: {
+            Label("JSON Input", systemImage: "curlybraces")
+        }
+    }
+
+    @ViewBuilder
+    private var previewSection: some View {
+        if let servers = viewModel.parsedServers, !servers.isEmpty {
+            GroupBox {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                        Text("\(viewModel.serverCount) server(s) detected")
+                            .fontWeight(.medium)
+                    }
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(viewModel.serverNames, id: \.self) { name in
+                            HStack {
+                                let server = servers[name]
+                                Image(systemName: server?.isHTTP == true ? "globe" : "terminal")
+                                    .foregroundStyle(server?.isHTTP == true ? .blue : .green)
+                                    .font(.caption)
+                                Text(name)
+                                    .font(.system(.caption, design: .monospaced))
+                                Spacer()
+                                Text(server?.isHTTP == true ? "HTTP" : "Stdio")
+                                    .font(.caption2)
+                                    .padding(.horizontal, 6)
+                                    .padding(.vertical, 2)
+                                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 4))
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            } label: {
+                Label("Preview", systemImage: "eye")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var destinationSection: some View {
+        if viewModel.parsedServers != nil {
+            GroupBox {
+                VStack(alignment: .leading, spacing: 8) {
+                    if viewModel.availableDestinations.isEmpty {
+                        Text("No destinations available")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Picker("Import to", selection: $viewModel.selectedDestination) {
+                            Text("Select destination...")
+                                .tag(nil as CopyDestination?)
+
+                            ForEach(viewModel.availableDestinations) { destination in
+                                Label(destination.displayName, systemImage: destination.icon)
+                                    .tag(destination as CopyDestination?)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                    }
+                }
+                .padding(.vertical, 4)
+            } label: {
+                Label("Destination", systemImage: "arrow.right.square")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var conflictSection: some View {
+        if viewModel.parsedServers != nil {
+            GroupBox {
+                Picker("If server already exists", selection: $viewModel.conflictStrategy) {
+                    ForEach(
+                        [ConflictStrategy.rename, .overwrite, .skip],
+                        id: \.self
+                    ) { strategy in
+                        Text(strategy.displayName).tag(strategy)
+                    }
+                }
+                .pickerStyle(.menu)
+                .padding(.vertical, 4)
+            } label: {
+                Label("Conflict Resolution", systemImage: "arrow.triangle.2.circlepath")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func resultSection(result: BulkImportResult) -> some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 8) {
+                if result.totalImported > 0 {
+                    HStack {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                        Text(result.summary)
+                    }
+
+                    if !result.renamed.isEmpty {
+                        ForEach(Array(result.renamed.sorted(by: { $0.key < $1.key })), id: \.key) { old, new in
+                            HStack {
+                                Text(old)
+                                    .font(.system(.caption, design: .monospaced))
+                                    .strikethrough()
+                                    .foregroundStyle(.secondary)
+                                Image(systemName: "arrow.right")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                Text(new)
+                                    .font(.system(.caption, design: .monospaced))
+                            }
+                        }
+                    }
+                } else {
+                    HStack {
+                        Image(systemName: "info.circle.fill")
+                            .foregroundStyle(.orange)
+                        Text(result.summary)
+                    }
+                }
+
+                if !result.errors.isEmpty {
+                    ForEach(result.errors, id: \.self) { error in
+                        HStack {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundStyle(.red)
+                                .font(.caption)
+                            Text(error)
+                                .font(.caption)
+                                .foregroundStyle(.red)
+                        }
+                    }
+                }
+            }
+            .padding(.vertical, 4)
+        } label: {
+            Label("Result", systemImage: "checkmark.seal")
+        }
+    }
+
+    @ViewBuilder
+    private func errorSection(error: String) -> some View {
+        GroupBox {
+            HStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+                Text(error)
+                    .foregroundStyle(.red)
+            }
+            .padding(.vertical, 4)
+        } label: {
+            Label("Error", systemImage: "xmark.octagon")
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            Button("Cancel") {
+                dismiss()
+            }
+            .keyboardShortcut(.cancelAction)
+
+            Spacer()
+
+            if viewModel.importSucceeded {
+                Button("Done") {
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+            } else {
+                Button("Import") {
+                    Task {
+                        await viewModel.performImport()
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!viewModel.canImport)
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    MCPPasteSheet(
+        viewModel: MCPPasteViewModel(
+            currentProject: .project(path: "/tmp/project", name: "My Project")
+        )
+    )
+}

--- a/Fig/Sources/Views/MCPServerEditorView.swift
+++ b/Fig/Sources/Views/MCPServerEditorView.swift
@@ -13,13 +13,11 @@ struct MCPServerEditorView: View {
     }
 
     @Bindable var viewModel: MCPServerEditorViewModel
-    @Environment(\.dismiss) private var dismiss
-    @FocusState private var focusedField: Field?
 
     var body: some View {
         VStack(spacing: 0) {
             // Header
-            header
+            self.header
 
             Divider()
 
@@ -27,20 +25,20 @@ struct MCPServerEditorView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
                     // Server identity section
-                    identitySection
+                    self.identitySection
 
                     // Target location section
-                    scopeSection
+                    self.scopeSection
 
                     // Type-specific configuration
-                    if viewModel.formData.serverType == .stdio {
-                        stdioSection
+                    if self.viewModel.formData.serverType == .stdio {
+                        self.stdioSection
                     } else {
-                        httpSection
+                        self.httpSection
                     }
 
                     // Import section
-                    importSection
+                    self.importSection
                 }
                 .padding()
             }
@@ -48,39 +46,46 @@ struct MCPServerEditorView: View {
             Divider()
 
             // Footer with buttons
-            footer
+            self.footer
         }
         .frame(width: 550, height: 600)
-        .onChange(of: viewModel.formData.name) { _, _ in viewModel.validate() }
-        .onChange(of: viewModel.formData.command) { _, _ in viewModel.validate() }
-        .onChange(of: viewModel.formData.url) { _, _ in viewModel.validate() }
-        .onChange(of: viewModel.formData.scope) { _, _ in viewModel.validate() }
+        .onChange(of: self.viewModel.formData.name) { _, _ in self.viewModel.validate() }
+        .onChange(of: self.viewModel.formData.command) { _, _ in self.viewModel.validate() }
+        .onChange(of: self.viewModel.formData.url) { _, _ in self.viewModel.validate() }
+        .onChange(of: self.viewModel.formData.scope) { _, _ in self.viewModel.validate() }
         .onAppear {
-            viewModel.validate()
-            focusedField = viewModel.isEditing ? .command : .name
+            self.viewModel.validate()
+            self.focusedField = self.viewModel.isEditing ? .command : .name
         }
     }
 
     // MARK: Private
 
-    @State private var showImportSheet = false
-    @State private var importText = ""
-    @State private var importType: ImportType = .json
-
     private enum ImportType: String, CaseIterable, Identifiable {
         case json = "JSON"
         case cli = "CLI Command"
 
-        var id: String { rawValue }
+        // MARK: Internal
+
+        var id: String {
+            rawValue
+        }
     }
+
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var focusedField: Field?
+
+    @State private var showImportSheet = false
+    @State private var importText = ""
+    @State private var importType: ImportType = .json
 
     private var header: some View {
         HStack {
-            Image(systemName: viewModel.formData.serverType.icon)
+            Image(systemName: self.viewModel.formData.serverType.icon)
                 .font(.title2)
-                .foregroundStyle(viewModel.formData.serverType == .http ? .blue : .green)
+                .foregroundStyle(self.viewModel.formData.serverType == .http ? .blue : .green)
 
-            Text(viewModel.formTitle)
+            Text(self.viewModel.formTitle)
                 .font(.headline)
 
             Spacer()
@@ -97,9 +102,9 @@ struct MCPServerEditorView: View {
                         .font(.subheadline)
                         .fontWeight(.medium)
 
-                    TextField("my-server", text: $viewModel.formData.name)
+                    TextField("my-server", text: self.$viewModel.formData.name)
                         .textFieldStyle(.roundedBorder)
-                        .focused($focusedField, equals: .name)
+                        .focused(self.$focusedField, equals: .name)
                         .accessibilityLabel("Server name")
 
                     if let error = viewModel.error(for: "name") {
@@ -115,7 +120,7 @@ struct MCPServerEditorView: View {
                         .font(.subheadline)
                         .fontWeight(.medium)
 
-                    Picker("Type", selection: $viewModel.formData.serverType) {
+                    Picker("Type", selection: self.$viewModel.formData.serverType) {
                         ForEach(MCPServerType.allCases) { type in
                             Label(type.displayName, systemImage: type.icon)
                                 .tag(type)
@@ -137,14 +142,14 @@ struct MCPServerEditorView: View {
                     .font(.subheadline)
                     .fontWeight(.medium)
 
-                Picker("Scope", selection: $viewModel.formData.scope) {
+                Picker("Scope", selection: self.$viewModel.formData.scope) {
                     ForEach(MCPServerScope.allCases) { scope in
                         Label(scope.displayName, systemImage: scope.icon)
                             .tag(scope)
                     }
                 }
                 .pickerStyle(.radioGroup)
-                .disabled(viewModel.projectPath == nil && viewModel.formData.scope == .project)
+                .disabled(self.viewModel.projectPath == nil && self.viewModel.formData.scope == .project)
             }
             .padding(.vertical, 4)
         } label: {
@@ -161,10 +166,10 @@ struct MCPServerEditorView: View {
                         .font(.subheadline)
                         .fontWeight(.medium)
 
-                    TextField("npx", text: $viewModel.formData.command)
+                    TextField("npx", text: self.$viewModel.formData.command)
                         .textFieldStyle(.roundedBorder)
                         .font(.system(.body, design: .monospaced))
-                        .focused($focusedField, equals: .command)
+                        .focused(self.$focusedField, equals: .command)
                         .accessibilityLabel("Command")
 
                     if let error = viewModel.error(for: "command") {
@@ -184,7 +189,7 @@ struct MCPServerEditorView: View {
                     }
 
                     TagInputView(
-                        tags: $viewModel.formData.args,
+                        tags: self.$viewModel.formData.args,
                         placeholder: "Add argument..."
                     )
                 }
@@ -197,7 +202,7 @@ struct MCPServerEditorView: View {
                             .fontWeight(.medium)
                         Spacer()
                         Button {
-                            viewModel.formData.addEnvVar()
+                            self.viewModel.formData.addEnvVar()
                         } label: {
                             Image(systemName: "plus.circle")
                         }
@@ -205,19 +210,19 @@ struct MCPServerEditorView: View {
                         .accessibilityLabel("Add environment variable")
                     }
 
-                    if viewModel.formData.envVars.isEmpty {
+                    if self.viewModel.formData.envVars.isEmpty {
                         Text("No environment variables")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     } else {
-                        ForEach(Array(viewModel.formData.envVars.enumerated()), id: \.element.id) { index, _ in
+                        ForEach(Array(self.viewModel.formData.envVars.enumerated()), id: \.element.id) { index, _ in
                             KeyValueRow(
-                                key: $viewModel.formData.envVars[index].key,
-                                value: $viewModel.formData.envVars[index].value,
+                                key: self.$viewModel.formData.envVars[index].key,
+                                value: self.$viewModel.formData.envVars[index].value,
                                 keyPlaceholder: "KEY",
                                 valuePlaceholder: "value",
                                 onDelete: {
-                                    viewModel.formData.removeEnvVar(at: index)
+                                    self.viewModel.formData.removeEnvVar(at: index)
                                 }
                             )
                         }
@@ -239,10 +244,10 @@ struct MCPServerEditorView: View {
                         .font(.subheadline)
                         .fontWeight(.medium)
 
-                    TextField("https://mcp.example.com/api", text: $viewModel.formData.url)
+                    TextField("https://mcp.example.com/api", text: self.$viewModel.formData.url)
                         .textFieldStyle(.roundedBorder)
                         .font(.system(.body, design: .monospaced))
-                        .focused($focusedField, equals: .url)
+                        .focused(self.$focusedField, equals: .url)
                         .accessibilityLabel("Server URL")
 
                     if let error = viewModel.error(for: "url") {
@@ -260,7 +265,7 @@ struct MCPServerEditorView: View {
                             .fontWeight(.medium)
                         Spacer()
                         Button {
-                            viewModel.formData.addHeader()
+                            self.viewModel.formData.addHeader()
                         } label: {
                             Image(systemName: "plus.circle")
                         }
@@ -268,19 +273,19 @@ struct MCPServerEditorView: View {
                         .accessibilityLabel("Add header")
                     }
 
-                    if viewModel.formData.headers.isEmpty {
+                    if self.viewModel.formData.headers.isEmpty {
                         Text("No headers")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     } else {
-                        ForEach(Array(viewModel.formData.headers.enumerated()), id: \.element.id) { index, _ in
+                        ForEach(Array(self.viewModel.formData.headers.enumerated()), id: \.element.id) { index, _ in
                             KeyValueRow(
-                                key: $viewModel.formData.headers[index].key,
-                                value: $viewModel.formData.headers[index].value,
+                                key: self.$viewModel.formData.headers[index].key,
+                                value: self.$viewModel.formData.headers[index].value,
                                 keyPlaceholder: "Header-Name",
                                 valuePlaceholder: "value",
                                 onDelete: {
-                                    viewModel.formData.removeHeader(at: index)
+                                    self.viewModel.formData.removeHeader(at: index)
                                 }
                             )
                         }
@@ -296,14 +301,14 @@ struct MCPServerEditorView: View {
     private var importSection: some View {
         DisclosureGroup {
             VStack(alignment: .leading, spacing: 12) {
-                Picker("Import Type", selection: $importType) {
+                Picker("Import Type", selection: self.$importType) {
                     ForEach(ImportType.allCases) { type in
                         Text(type.rawValue).tag(type)
                     }
                 }
                 .pickerStyle(.segmented)
 
-                TextEditor(text: $importText)
+                TextEditor(text: self.$importText)
                     .font(.system(.caption, design: .monospaced))
                     .frame(height: 80)
                     .overlay(
@@ -314,16 +319,16 @@ struct MCPServerEditorView: View {
                 HStack {
                     Spacer()
                     Button("Import") {
-                        let success = if importType == .json {
-                            viewModel.importFromJSON(importText)
+                        let success = if self.importType == .json {
+                            self.viewModel.importFromJSON(self.importText)
                         } else {
-                            viewModel.importFromCLICommand(importText)
+                            self.viewModel.importFromCLICommand(self.importText)
                         }
                         if success {
-                            importText = ""
+                            self.importText = ""
                         }
                     }
-                    .disabled(importText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .disabled(self.importText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
             .padding(.top, 8)
@@ -336,21 +341,21 @@ struct MCPServerEditorView: View {
     private var footer: some View {
         HStack {
             Button("Cancel") {
-                dismiss()
+                self.dismiss()
             }
             .keyboardShortcut(.cancelAction)
 
             Spacer()
 
-            Button(viewModel.isEditing ? "Save" : "Add Server") {
+            Button(self.viewModel.isEditing ? "Save" : "Add Server") {
                 Task {
-                    if await viewModel.save() {
-                        dismiss()
+                    if await self.viewModel.save() {
+                        self.dismiss()
                     }
                 }
             }
             .buttonStyle(.borderedProminent)
-            .disabled(!viewModel.canSave)
+            .disabled(!self.viewModel.canSave)
             .keyboardShortcut(.defaultAction)
         }
         .padding()
@@ -361,47 +366,54 @@ struct MCPServerEditorView: View {
 
 /// A view for entering tags/arguments with add/remove functionality.
 struct TagInputView: View {
-    @Binding var tags: [String]
-    var placeholder: String = "Add tag..."
+    // MARK: Internal
 
-    @State private var newTagText = ""
+    @Binding var tags: [String]
+
+    var placeholder: String = "Add tag..."
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             // Tag display
             FlowLayout(spacing: 4) {
-                ForEach(Array(tags.enumerated()), id: \.offset) { index, tag in
+                ForEach(Array(self.tags.enumerated()), id: \.offset) { index, tag in
                     TagChip(text: tag) {
-                        tags.remove(at: index)
+                        self.tags.remove(at: index)
                     }
                 }
             }
 
             // Input field
             HStack {
-                TextField(placeholder, text: $newTagText)
+                TextField(self.placeholder, text: self.$newTagText)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
                     .onSubmit {
-                        addTag()
+                        self.addTag()
                     }
 
                 Button {
-                    addTag()
+                    self.addTag()
                 } label: {
                     Image(systemName: "plus.circle.fill")
                 }
                 .buttonStyle(.plain)
-                .disabled(newTagText.trimmingCharacters(in: .whitespaces).isEmpty)
+                .disabled(self.newTagText.trimmingCharacters(in: .whitespaces).isEmpty)
             }
         }
     }
 
+    // MARK: Private
+
+    @State private var newTagText = ""
+
     private func addTag() {
-        let trimmed = newTagText.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty else { return }
-        tags.append(trimmed)
-        newTagText = ""
+        let trimmed = self.newTagText.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else {
+            return
+        }
+        self.tags.append(trimmed)
+        self.newTagText = ""
     }
 }
 
@@ -414,17 +426,17 @@ struct TagChip: View {
 
     var body: some View {
         HStack(spacing: 4) {
-            Text(text)
+            Text(self.text)
                 .font(.system(.caption, design: .monospaced))
 
             Button {
-                onRemove()
+                self.onRemove()
             } label: {
                 Image(systemName: "xmark.circle.fill")
                     .font(.caption2)
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Remove \(text)")
+            .accessibilityLabel("Remove \(self.text)")
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
@@ -438,13 +450,14 @@ struct TagChip: View {
 struct KeyValueRow: View {
     @Binding var key: String
     @Binding var value: String
+
     var keyPlaceholder: String = "Key"
     var valuePlaceholder: String = "Value"
     var onDelete: () -> Void
 
     var body: some View {
         HStack(spacing: 8) {
-            TextField(keyPlaceholder, text: $key)
+            TextField(self.keyPlaceholder, text: self.$key)
                 .textFieldStyle(.roundedBorder)
                 .font(.system(.caption, design: .monospaced))
                 .frame(width: 150)
@@ -452,12 +465,12 @@ struct KeyValueRow: View {
             Text("=")
                 .foregroundStyle(.secondary)
 
-            TextField(valuePlaceholder, text: $value)
+            TextField(self.valuePlaceholder, text: self.$value)
                 .textFieldStyle(.roundedBorder)
                 .font(.system(.caption, design: .monospaced))
 
             Button {
-                onDelete()
+                self.onDelete()
             } label: {
                 Image(systemName: "minus.circle.fill")
                     .foregroundStyle(.red)

--- a/Fig/Sources/Views/Onboarding/OnboardingDiscoveryView.swift
+++ b/Fig/Sources/Views/Onboarding/OnboardingDiscoveryView.swift
@@ -82,27 +82,6 @@ struct OnboardingDiscoveryView: View {
         }
     }
 
-    private func errorContent(_ error: String) -> some View {
-        VStack(spacing: 16) {
-            Text("Discovery Issue")
-                .font(.largeTitle)
-                .fontWeight(.bold)
-
-            Text(error)
-                .font(.body)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 400)
-
-            Button("Retry") {
-                Task {
-                    await self.viewModel.runDiscovery()
-                }
-            }
-            .buttonStyle(.bordered)
-        }
-    }
-
     private var emptyContent: some View {
         VStack(spacing: 16) {
             Text("No Projects Found")
@@ -160,6 +139,27 @@ struct OnboardingDiscoveryView: View {
         .frame(maxHeight: 250)
         .background(.quaternary.opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func errorContent(_ error: String) -> some View {
+        VStack(spacing: 16) {
+            Text("Discovery Issue")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+
+            Text(error)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 400)
+
+            Button("Retry") {
+                Task {
+                    await self.viewModel.runDiscovery()
+                }
+            }
+            .buttonStyle(.bordered)
+        }
     }
 
     private func projectRow(_ project: DiscoveredProject) -> some View {

--- a/Fig/Sources/Views/Onboarding/OnboardingTourView.swift
+++ b/Fig/Sources/Views/Onboarding/OnboardingTourView.swift
@@ -70,10 +70,6 @@ struct OnboardingTourView: View {
         .animation(.easeInOut(duration: 0.25), value: self.viewModel.currentTourPage)
     }
 
-    private var isLastTourPage: Bool {
-        self.viewModel.currentTourPage == OnboardingViewModel.tourPageCount - 1
-    }
-
     // MARK: Private
 
     private struct TourPageData {
@@ -103,8 +99,27 @@ struct OnboardingTourView: View {
             icon: "globe",
             title: "Global Settings",
             description: "Manage global Claude Code settings that apply across all your projects. Set default permissions, environment variables, and hooks in one place."
-        )
+        ),
     ]
+
+    private var isLastTourPage: Bool {
+        self.viewModel.currentTourPage == OnboardingViewModel.tourPageCount - 1
+    }
+
+    private var pageIndicator: some View {
+        HStack(spacing: 8) {
+            ForEach(0 ..< OnboardingViewModel.tourPageCount, id: \.self) { index in
+                Circle()
+                    .fill(
+                        index == self.viewModel.currentTourPage
+                            ? Color.accentColor
+                            : Color.secondary.opacity(0.3)
+                    )
+                    .frame(width: 8, height: 8)
+            }
+        }
+    }
+
     // swiftlint:enable line_length
 
     @ViewBuilder
@@ -125,20 +140,6 @@ struct OnboardingTourView: View {
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 500)
-        }
-    }
-
-    private var pageIndicator: some View {
-        HStack(spacing: 8) {
-            ForEach(0 ..< OnboardingViewModel.tourPageCount, id: \.self) { index in
-                Circle()
-                    .fill(
-                        index == self.viewModel.currentTourPage
-                            ? Color.accentColor
-                            : Color.secondary.opacity(0.3)
-                    )
-                    .frame(width: 8, height: 8)
-            }
         }
     }
 }

--- a/Fig/Sources/Views/PermissionEditorViews.swift
+++ b/Fig/Sources/Views/PermissionEditorViews.swift
@@ -16,8 +16,8 @@ struct PermissionRuleEditorView: View {
             VStack(alignment: .leading, spacing: 16) {
                 // Target selector and quick-add
                 HStack {
-                    if !viewModel.isGlobalMode {
-                        EditingTargetPicker(selection: $viewModel.editingTarget)
+                    if !self.viewModel.isGlobalMode {
+                        EditingTargetPicker(selection: self.$viewModel.editingTarget)
                     }
 
                     Spacer()
@@ -25,7 +25,7 @@ struct PermissionRuleEditorView: View {
                     Menu {
                         ForEach(PermissionPreset.allPresets) { preset in
                             Button {
-                                viewModel.applyPreset(preset)
+                                self.viewModel.applyPreset(preset)
                             } label: {
                                 VStack(alignment: .leading) {
                                     Text(preset.name)
@@ -51,33 +51,33 @@ struct PermissionRuleEditorView: View {
                             Spacer()
 
                             Button {
-                                showingAddAllowRule = true
+                                self.showingAddAllowRule = true
                             } label: {
                                 Label("Add Rule", systemImage: "plus")
                             }
                             .buttonStyle(.borderless)
                         }
 
-                        if viewModel.allowRules.isEmpty {
+                        if self.viewModel.allowRules.isEmpty {
                             Text("No allow rules configured.")
                                 .foregroundStyle(.secondary)
                                 .padding(.vertical, 8)
                         } else {
-                            ForEach(viewModel.allowRules) { rule in
+                            ForEach(self.viewModel.allowRules) { rule in
                                 EditablePermissionRuleRow(
                                     rule: rule,
                                     onUpdate: { newRule, newType in
-                                        viewModel.updatePermissionRule(rule, newRule: newRule, newType: newType)
+                                        self.viewModel.updatePermissionRule(rule, newRule: newRule, newType: newType)
                                     },
                                     onDelete: {
-                                        viewModel.removePermissionRule(rule)
+                                        self.viewModel.removePermissionRule(rule)
                                     },
-                                    validateRule: viewModel.validatePermissionRule,
+                                    validateRule: self.viewModel.validatePermissionRule,
                                     isDuplicate: { ruleStr, type in
-                                        viewModel.isRuleDuplicate(ruleStr, type: type, excluding: rule)
+                                        self.viewModel.isRuleDuplicate(ruleStr, type: type, excluding: rule)
                                     },
-                                    onPromoteToGlobal: onPromoteToGlobal != nil ? {
-                                        onPromoteToGlobal?(rule.rule, .allow)
+                                    onPromoteToGlobal: self.onPromoteToGlobal != nil ? {
+                                        self.onPromoteToGlobal?(rule.rule, .allow)
                                     } : nil
                                 )
                             }
@@ -97,33 +97,33 @@ struct PermissionRuleEditorView: View {
                             Spacer()
 
                             Button {
-                                showingAddDenyRule = true
+                                self.showingAddDenyRule = true
                             } label: {
                                 Label("Add Rule", systemImage: "plus")
                             }
                             .buttonStyle(.borderless)
                         }
 
-                        if viewModel.denyRules.isEmpty {
+                        if self.viewModel.denyRules.isEmpty {
                             Text("No deny rules configured.")
                                 .foregroundStyle(.secondary)
                                 .padding(.vertical, 8)
                         } else {
-                            ForEach(viewModel.denyRules) { rule in
+                            ForEach(self.viewModel.denyRules) { rule in
                                 EditablePermissionRuleRow(
                                     rule: rule,
                                     onUpdate: { newRule, newType in
-                                        viewModel.updatePermissionRule(rule, newRule: newRule, newType: newType)
+                                        self.viewModel.updatePermissionRule(rule, newRule: newRule, newType: newType)
                                     },
                                     onDelete: {
-                                        viewModel.removePermissionRule(rule)
+                                        self.viewModel.removePermissionRule(rule)
                                     },
-                                    validateRule: viewModel.validatePermissionRule,
+                                    validateRule: self.viewModel.validatePermissionRule,
                                     isDuplicate: { ruleStr, type in
-                                        viewModel.isRuleDuplicate(ruleStr, type: type, excluding: rule)
+                                        self.viewModel.isRuleDuplicate(ruleStr, type: type, excluding: rule)
                                     },
-                                    onPromoteToGlobal: onPromoteToGlobal != nil ? {
-                                        onPromoteToGlobal?(rule.rule, .deny)
+                                    onPromoteToGlobal: self.onPromoteToGlobal != nil ? {
+                                        self.onPromoteToGlobal?(rule.rule, .deny)
                                     } : nil
                                 )
                             }
@@ -136,22 +136,22 @@ struct PermissionRuleEditorView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .sheet(isPresented: $showingAddAllowRule) {
+        .sheet(isPresented: self.$showingAddAllowRule) {
             AddPermissionRuleSheet(type: .allow) { rule in
-                viewModel.addPermissionRule(rule, type: .allow)
+                self.viewModel.addPermissionRule(rule, type: .allow)
             } validateRule: { rule in
-                viewModel.validatePermissionRule(rule)
+                self.viewModel.validatePermissionRule(rule)
             } isDuplicate: { rule in
-                viewModel.isRuleDuplicate(rule, type: .allow)
+                self.viewModel.isRuleDuplicate(rule, type: .allow)
             }
         }
-        .sheet(isPresented: $showingAddDenyRule) {
+        .sheet(isPresented: self.$showingAddDenyRule) {
             AddPermissionRuleSheet(type: .deny) { rule in
-                viewModel.addPermissionRule(rule, type: .deny)
+                self.viewModel.addPermissionRule(rule, type: .deny)
             } validateRule: { rule in
-                viewModel.validatePermissionRule(rule)
+                self.viewModel.validatePermissionRule(rule)
             } isDuplicate: { rule in
-                viewModel.isRuleDuplicate(rule, type: .deny)
+                self.viewModel.isRuleDuplicate(rule, type: .deny)
             }
         }
     }
@@ -177,29 +177,29 @@ struct EditablePermissionRuleRow: View {
 
     var body: some View {
         HStack {
-            Image(systemName: rule.type.icon)
-                .foregroundStyle(rule.type == .allow ? .green : .red)
+            Image(systemName: self.rule.type.icon)
+                .foregroundStyle(self.rule.type == .allow ? .green : .red)
                 .frame(width: 20)
 
-            if isEditing {
-                TextField("Rule pattern", text: $editedRule)
+            if self.isEditing {
+                TextField("Rule pattern", text: self.$editedRule)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
                     .onSubmit {
-                        saveEdit()
+                        self.saveEdit()
                     }
 
                 Button("Save") {
-                    saveEdit()
+                    self.saveEdit()
                 }
-                .disabled(!canSave)
+                .disabled(!self.canSave)
 
                 Button("Cancel") {
-                    isEditing = false
-                    editedRule = rule.rule
+                    self.isEditing = false
+                    self.editedRule = self.rule.rule
                 }
             } else {
-                Text(rule.rule)
+                Text(self.rule.rule)
                     .font(.system(.body, design: .monospaced))
                     .lineLimit(1)
                     .truncationMode(.middle)
@@ -207,8 +207,8 @@ struct EditablePermissionRuleRow: View {
                 Spacer()
 
                 Button {
-                    isEditing = true
-                    editedRule = rule.rule
+                    self.isEditing = true
+                    self.editedRule = self.rule.rule
                 } label: {
                     Image(systemName: "pencil")
                         .font(.caption)
@@ -216,7 +216,7 @@ struct EditablePermissionRuleRow: View {
                 .buttonStyle(.plain)
 
                 Button {
-                    showingDeleteConfirmation = true
+                    self.showingDeleteConfirmation = true
                 } label: {
                     Image(systemName: "trash")
                         .font(.caption)
@@ -233,20 +233,20 @@ struct EditablePermissionRuleRow: View {
         )
         .confirmationDialog(
             "Delete Rule",
-            isPresented: $showingDeleteConfirmation,
+            isPresented: self.$showingDeleteConfirmation,
             titleVisibility: .visible
         ) {
             Button("Delete", role: .destructive) {
-                onDelete()
+                self.onDelete()
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("Are you sure you want to delete this rule?\n\(rule.rule)")
+            Text("Are you sure you want to delete this rule?\n\(self.rule.rule)")
         }
         .contextMenu {
             Button {
                 NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(rule.rule, forType: .string)
+                NSPasteboard.general.setString(self.rule.rule, forType: .string)
             } label: {
                 Label("Copy Rule", systemImage: "doc.on.doc")
             }
@@ -264,7 +264,7 @@ struct EditablePermissionRuleRow: View {
             Divider()
 
             Button(role: .destructive) {
-                showingDeleteConfirmation = true
+                self.showingDeleteConfirmation = true
             } label: {
                 Label("Delete", systemImage: "trash")
             }
@@ -278,14 +278,16 @@ struct EditablePermissionRuleRow: View {
     @State private var showingDeleteConfirmation = false
 
     private var canSave: Bool {
-        let validation = validateRule(editedRule)
-        return validation.isValid && !isDuplicate(editedRule, rule.type)
+        let validation = self.validateRule(self.editedRule)
+        return validation.isValid && !self.isDuplicate(self.editedRule, self.rule.type)
     }
 
     private func saveEdit() {
-        guard canSave else { return }
-        onUpdate(editedRule, rule.type)
-        isEditing = false
+        guard self.canSave else {
+            return
+        }
+        self.onUpdate(self.editedRule, self.rule.type)
+        self.isEditing = false
     }
 }
 
@@ -318,10 +320,10 @@ struct AddPermissionRuleSheet: View {
         VStack(alignment: .leading, spacing: 16) {
             // Header
             HStack {
-                Image(systemName: type == .allow ? "checkmark.circle.fill" : "xmark.circle.fill")
-                    .foregroundStyle(type == .allow ? .green : .red)
+                Image(systemName: self.type == .allow ? "checkmark.circle.fill" : "xmark.circle.fill")
+                    .foregroundStyle(self.type == .allow ? .green : .red)
                     .font(.title2)
-                Text("Add \(type == .allow ? "Allow" : "Deny") Rule")
+                Text("Add \(self.type == .allow ? "Allow" : "Deny") Rule")
                     .font(.title2)
                     .fontWeight(.semibold)
             }
@@ -332,7 +334,7 @@ struct AddPermissionRuleSheet: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Tool Type")
                     .font(.headline)
-                Picker("Tool Type", selection: $selectedTool) {
+                Picker("Tool Type", selection: self.$selectedTool) {
                     ForEach(ToolType.allCases) { tool in
                         Text(tool.rawValue).tag(tool)
                     }
@@ -341,11 +343,11 @@ struct AddPermissionRuleSheet: View {
             }
 
             // Custom tool name (if custom selected)
-            if selectedTool == .custom {
+            if self.selectedTool == .custom {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Custom Tool Name")
                         .font(.headline)
-                    TextField("ToolName", text: $customToolName)
+                    TextField("ToolName", text: self.$customToolName)
                         .textFieldStyle(.roundedBorder)
                 }
             }
@@ -354,7 +356,7 @@ struct AddPermissionRuleSheet: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Pattern (optional)")
                     .font(.headline)
-                TextField(selectedTool.placeholder, text: $pattern)
+                TextField(self.selectedTool.placeholder, text: self.$pattern)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
                 Text("Use * for wildcard, ** for recursive match")
@@ -367,9 +369,9 @@ struct AddPermissionRuleSheet: View {
                 Text("Preview")
                     .font(.headline)
                 HStack {
-                    Image(systemName: type.icon)
-                        .foregroundStyle(type == .allow ? .green : .red)
-                    Text(generatedRule)
+                    Image(systemName: self.type.icon)
+                        .foregroundStyle(self.type == .allow ? .green : .red)
+                    Text(self.generatedRule)
                         .font(.system(.body, design: .monospaced))
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
@@ -393,18 +395,18 @@ struct AddPermissionRuleSheet: View {
             // Buttons
             HStack {
                 Button("Cancel") {
-                    dismiss()
+                    self.dismiss()
                 }
                 .keyboardShortcut(.cancelAction)
 
                 Spacer()
 
                 Button("Add Rule") {
-                    onAdd(generatedRule)
-                    dismiss()
+                    self.onAdd(self.generatedRule)
+                    self.dismiss()
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(!isValid)
+                .disabled(!self.isValid)
             }
         }
         .padding()
@@ -421,29 +423,29 @@ struct AddPermissionRuleSheet: View {
     @State private var pattern = ""
 
     private var toolName: String {
-        selectedTool == .custom ? customToolName : selectedTool.rawValue
+        self.selectedTool == .custom ? self.customToolName : self.selectedTool.rawValue
     }
 
     private var generatedRule: String {
-        if pattern.isEmpty {
-            return toolName
+        if self.pattern.isEmpty {
+            return self.toolName
         }
-        return "\(toolName)(\(pattern))"
+        return "\(self.toolName)(\(self.pattern))"
     }
 
     private var validationError: String? {
-        if selectedTool == .custom, customToolName.isEmpty {
+        if self.selectedTool == .custom, self.customToolName.isEmpty {
             return "Enter a custom tool name"
         }
-        if isDuplicate(generatedRule) {
+        if self.isDuplicate(self.generatedRule) {
             return "This rule already exists"
         }
-        let validation = validateRule(generatedRule)
+        let validation = self.validateRule(self.generatedRule)
         return validation.error
     }
 
     private var isValid: Bool {
-        validationError == nil && !toolName.isEmpty
+        self.validationError == nil && !self.toolName.isEmpty
     }
 }
 
@@ -461,6 +463,7 @@ struct RulePromotionInfo {
 struct PromoteToGlobalModifier: ViewModifier {
     @Binding var isPresented: Bool
     @Binding var ruleToPromote: RulePromotionInfo?
+
     let projectURL: URL?
     var onComplete: (() async -> Void)?
 
@@ -468,8 +471,8 @@ struct PromoteToGlobalModifier: ViewModifier {
         content
             .alert(
                 "Promote to Global",
-                isPresented: $isPresented,
-                presenting: ruleToPromote
+                isPresented: self.$isPresented,
+                presenting: self.ruleToPromote
             ) { ruleInfo in
                 Button("Cancel", role: .cancel) {}
                 Button("Promote") {
@@ -479,7 +482,7 @@ struct PromoteToGlobalModifier: ViewModifier {
                                 rule: ruleInfo.rule,
                                 type: ruleInfo.type,
                                 to: .global,
-                                projectPath: projectURL
+                                projectPath: self.projectURL
                             )
                             if added {
                                 NotificationManager.shared.showSuccess(
@@ -492,7 +495,7 @@ struct PromoteToGlobalModifier: ViewModifier {
                                     message: "This rule already exists in global settings"
                                 )
                             }
-                            await onComplete?()
+                            await self.onComplete?()
                         } catch {
                             NotificationManager.shared.showError(error)
                         }
@@ -526,7 +529,7 @@ extension View {
     viewModel.permissionRules = [
         EditablePermissionRule(rule: "Bash(npm run *)", type: .allow),
         EditablePermissionRule(rule: "Read(src/**)", type: .allow),
-        EditablePermissionRule(rule: "Read(.env)", type: .deny)
+        EditablePermissionRule(rule: "Read(.env)", type: .deny),
     ]
 
     return PermissionRuleEditorView(viewModel: viewModel)

--- a/Fig/Sources/Views/SettingsEditorViews.swift
+++ b/Fig/Sources/Views/SettingsEditorViews.swift
@@ -5,11 +5,12 @@ import SwiftUI
 /// Picker for selecting the editing target file.
 struct EditingTargetPicker: View {
     @Binding var selection: EditingTarget
+
     var targets: [EditingTarget] = EditingTarget.projectTargets
 
     var body: some View {
-        Picker("Save to:", selection: $selection) {
-            ForEach(targets) { target in
+        Picker("Save to:", selection: self.$selection) {
+            ForEach(self.targets) { target in
                 HStack {
                     Image(systemName: target.source.icon)
                     Text(target.label)
@@ -19,7 +20,7 @@ struct EditingTargetPicker: View {
         }
         .pickerStyle(.segmented)
         .frame(maxWidth: 350)
-        .help(selection.description)
+        .help(self.selection.description)
     }
 }
 
@@ -27,8 +28,6 @@ struct EditingTargetPicker: View {
 
 /// Sheet for resolving external file change conflicts.
 struct ConflictResolutionSheet: View {
-    // MARK: Internal
-
     let fileName: String
     let onResolve: (ConflictResolution) -> Void
 
@@ -44,7 +43,7 @@ struct ConflictResolutionSheet: View {
                     .fontWeight(.semibold)
             }
 
-            Text("The file \(fileName) was modified externally while you have unsaved changes.")
+            Text("The file \(self.fileName) was modified externally while you have unsaved changes.")
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
 
@@ -52,7 +51,7 @@ struct ConflictResolutionSheet: View {
 
             VStack(spacing: 12) {
                 Button {
-                    onResolve(.keepLocal)
+                    self.onResolve(.keepLocal)
                 } label: {
                     HStack {
                         Image(systemName: "pencil.circle.fill")
@@ -72,7 +71,7 @@ struct ConflictResolutionSheet: View {
                 .buttonStyle(.plain)
 
                 Button {
-                    onResolve(.useExternal)
+                    self.onResolve(.useExternal)
                 } label: {
                     HStack {
                         Image(systemName: "arrow.down.circle.fill")
@@ -106,7 +105,7 @@ struct DirtyStateIndicator: View {
     let isDirty: Bool
 
     var body: some View {
-        if isDirty {
+        if self.isDirty {
             Circle()
                 .fill(.orange)
                 .frame(width: 8, height: 8)
@@ -125,15 +124,15 @@ struct SaveButton: View {
     let action: () -> Void
 
     var body: some View {
-        Button(action: action) {
-            if isSaving {
+        Button(action: self.action) {
+            if self.isSaving {
                 ProgressView()
                     .controlSize(.small)
             } else {
                 Label("Save", systemImage: "square.and.arrow.down")
             }
         }
-        .disabled(!isDirty || isSaving)
+        .disabled(!self.isDirty || self.isSaving)
         .keyboardShortcut("s", modifiers: .command)
     }
 }
@@ -148,12 +147,12 @@ struct EditSettingsButton: View {
 
     var body: some View {
         Button {
-            showingEditor = true
+            self.showingEditor = true
         } label: {
             Label("Edit Settings", systemImage: "pencil")
         }
-        .sheet(isPresented: $showingEditor) {
-            ProjectSettingsEditorView(projectPath: projectPath)
+        .sheet(isPresented: self.$showingEditor) {
+            ProjectSettingsEditorView(projectPath: self.projectPath)
         }
     }
 

--- a/Fig/Tests/ConfigHealthCheckTests.swift
+++ b/Fig/Tests/ConfigHealthCheckTests.swift
@@ -30,7 +30,7 @@ enum HealthCheckTestHelpers {
     }
 }
 
-// MARK: - DenyListSecurityCheck Tests
+// MARK: - DenyListSecurityCheckTests
 
 @Suite("DenyListSecurityCheck Tests")
 struct DenyListSecurityCheckTests {
@@ -39,7 +39,7 @@ struct DenyListSecurityCheckTests {
     @Test("Flags missing .env deny rule")
     func flagsMissingEnvDeny() {
         let context = HealthCheckTestHelpers.makeContext()
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         let envFinding = findings.first { $0.title.contains(".env") }
         #expect(envFinding != nil)
@@ -50,7 +50,7 @@ struct DenyListSecurityCheckTests {
     @Test("Flags missing secrets/ deny rule")
     func flagsMissingSecretsDeny() {
         let context = HealthCheckTestHelpers.makeContext()
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         let secretsFinding = findings.first { $0.title.contains("secrets/") }
         #expect(secretsFinding != nil)
@@ -62,7 +62,7 @@ struct DenyListSecurityCheckTests {
     func noFindingWhenEnvDenied() {
         let settings = ClaudeSettings(permissions: Permissions(deny: ["Read(.env)"]))
         let context = HealthCheckTestHelpers.makeContext(projectSettings: settings)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         let envFinding = findings.first { $0.title.contains(".env") }
         #expect(envFinding == nil)
@@ -72,7 +72,7 @@ struct DenyListSecurityCheckTests {
     func noFindingWhenSecretsDenied() {
         let settings = ClaudeSettings(permissions: Permissions(deny: ["Read(secrets/**)"]))
         let context = HealthCheckTestHelpers.makeContext(projectSettings: settings)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         let secretsFinding = findings.first { $0.title.contains("secrets/") }
         #expect(secretsFinding == nil)
@@ -86,13 +86,13 @@ struct DenyListSecurityCheckTests {
             globalSettings: global,
             projectLocalSettings: local
         )
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
 }
 
-// MARK: - BroadAllowRulesCheck Tests
+// MARK: - BroadAllowRulesCheckTests
 
 @Suite("BroadAllowRulesCheck Tests")
 struct BroadAllowRulesCheckTests {
@@ -102,7 +102,7 @@ struct BroadAllowRulesCheckTests {
     func flagsBroadBash() {
         let settings = ClaudeSettings(permissions: Permissions(allow: ["Bash(*)"]))
         let context = HealthCheckTestHelpers.makeContext(projectSettings: settings)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.count == 1)
         #expect(findings.first?.severity == .warning)
@@ -113,7 +113,7 @@ struct BroadAllowRulesCheckTests {
     func doesNotFlagSpecific() {
         let settings = ClaudeSettings(permissions: Permissions(allow: ["Bash(npm run *)"]))
         let context = HealthCheckTestHelpers.makeContext(projectSettings: settings)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
@@ -122,7 +122,7 @@ struct BroadAllowRulesCheckTests {
     func flagsMultipleBroad() {
         let settings = ClaudeSettings(permissions: Permissions(allow: ["Bash(*)", "Read(*)"]))
         let context = HealthCheckTestHelpers.makeContext(projectSettings: settings)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.count == 2)
     }
@@ -131,13 +131,13 @@ struct BroadAllowRulesCheckTests {
     func noAutoFix() {
         let settings = ClaudeSettings(permissions: Permissions(allow: ["Bash(*)"]))
         let context = HealthCheckTestHelpers.makeContext(projectSettings: settings)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.first?.autoFix == nil)
     }
 }
 
-// MARK: - GlobalConfigSizeCheck Tests
+// MARK: - GlobalConfigSizeCheckTests
 
 @Suite("GlobalConfigSizeCheck Tests")
 struct GlobalConfigSizeCheckTests {
@@ -147,7 +147,7 @@ struct GlobalConfigSizeCheckTests {
     func flagsLargeConfig() {
         let size: Int64 = 6 * 1024 * 1024 // 6 MB
         let context = HealthCheckTestHelpers.makeContext(globalConfigFileSize: size)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.count == 1)
         #expect(findings.first?.severity == .warning)
@@ -158,7 +158,7 @@ struct GlobalConfigSizeCheckTests {
     func noFindingForSmall() {
         let size: Int64 = 1024 // 1 KB
         let context = HealthCheckTestHelpers.makeContext(globalConfigFileSize: size)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
@@ -166,13 +166,13 @@ struct GlobalConfigSizeCheckTests {
     @Test("No finding when size is unknown")
     func noFindingWhenUnknown() {
         let context = HealthCheckTestHelpers.makeContext(globalConfigFileSize: nil)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
 }
 
-// MARK: - MCPHardcodedSecretsCheck Tests
+// MARK: - MCPHardcodedSecretsCheckTests
 
 @Suite("MCPHardcodedSecretsCheck Tests")
 struct MCPHardcodedSecretsCheckTests {
@@ -183,7 +183,7 @@ struct MCPHardcodedSecretsCheckTests {
         let server = MCPServer(command: "npx", env: ["GITHUB_TOKEN": "ghp_1234567890abcdef"])
         let config = MCPConfig(mcpServers: ["github": server])
         let context = HealthCheckTestHelpers.makeContext(mcpConfig: config)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(!findings.isEmpty)
         #expect(findings.first?.severity == .warning)
@@ -194,7 +194,7 @@ struct MCPHardcodedSecretsCheckTests {
         let server = MCPServer(command: "npx", env: ["API_KEY": "some-long-api-key-value"])
         let config = MCPConfig(mcpServers: ["test": server])
         let context = HealthCheckTestHelpers.makeContext(mcpConfig: config)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(!findings.isEmpty)
     }
@@ -204,7 +204,7 @@ struct MCPHardcodedSecretsCheckTests {
         let server = MCPServer(command: "npx", env: ["NODE_ENV": "production"])
         let config = MCPConfig(mcpServers: ["test": server])
         let context = HealthCheckTestHelpers.makeContext(mcpConfig: config)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
@@ -216,7 +216,7 @@ struct MCPHardcodedSecretsCheckTests {
         ])
         let config = MCPConfig(mcpServers: ["remote": server])
         let context = HealthCheckTestHelpers.makeContext(mcpConfig: config)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(!findings.isEmpty)
     }
@@ -224,13 +224,13 @@ struct MCPHardcodedSecretsCheckTests {
     @Test("No findings when no MCP servers")
     func noFindingsNoServers() {
         let context = HealthCheckTestHelpers.makeContext()
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
 }
 
-// MARK: - LocalSettingsCheck Tests
+// MARK: - LocalSettingsCheckTests
 
 @Suite("LocalSettingsCheck Tests")
 struct LocalSettingsCheckTests {
@@ -239,7 +239,7 @@ struct LocalSettingsCheckTests {
     @Test("Suggests creating local settings when missing")
     func suggestsCreation() {
         let context = HealthCheckTestHelpers.makeContext(localSettingsExists: false)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.count == 1)
         #expect(findings.first?.severity == .suggestion)
@@ -249,13 +249,13 @@ struct LocalSettingsCheckTests {
     @Test("No finding when local settings exist")
     func noFindingWhenExists() {
         let context = HealthCheckTestHelpers.makeContext(localSettingsExists: true)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
 }
 
-// MARK: - MCPScopingCheck Tests
+// MARK: - MCPScopingCheckTests
 
 @Suite("MCPScopingCheck Tests")
 struct MCPScopingCheckTests {
@@ -270,7 +270,7 @@ struct MCPScopingCheckTests {
             legacyConfig: legacy,
             mcpConfigExists: false
         )
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.count == 1)
         #expect(findings.first?.severity == .suggestion)
@@ -285,7 +285,7 @@ struct MCPScopingCheckTests {
             legacyConfig: legacy,
             mcpConfigExists: true
         )
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
@@ -293,13 +293,13 @@ struct MCPScopingCheckTests {
     @Test("No finding when no global servers")
     func noFindingNoGlobalServers() {
         let context = HealthCheckTestHelpers.makeContext(mcpConfigExists: false)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
 }
 
-// MARK: - HookSuggestionsCheck Tests
+// MARK: - HookSuggestionsCheckTests
 
 @Suite("HookSuggestionsCheck Tests")
 struct HookSuggestionsCheckTests {
@@ -308,7 +308,7 @@ struct HookSuggestionsCheckTests {
     @Test("Suggests hooks when none configured")
     func suggestsHooks() {
         let context = HealthCheckTestHelpers.makeContext()
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.count == 1)
         #expect(findings.first?.severity == .suggestion)
@@ -321,13 +321,13 @@ struct HookSuggestionsCheckTests {
         ]
         let settings = ClaudeSettings(hooks: hooks)
         let context = HealthCheckTestHelpers.makeContext(projectSettings: settings)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
 }
 
-// MARK: - GoodPracticesCheck Tests
+// MARK: - GoodPracticesCheckTests
 
 @Suite("GoodPracticesCheck Tests")
 struct GoodPracticesCheckTests {
@@ -337,7 +337,7 @@ struct GoodPracticesCheckTests {
     func reportsEnvProtection() {
         let settings = ClaudeSettings(permissions: Permissions(deny: ["Read(.env)"]))
         let context = HealthCheckTestHelpers.makeContext(projectSettings: settings)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         let envFinding = findings.first { $0.title.contains("Sensitive files protected") }
         #expect(envFinding != nil)
@@ -347,7 +347,7 @@ struct GoodPracticesCheckTests {
     @Test("Reports good practice for local settings")
     func reportsLocalSettings() {
         let context = HealthCheckTestHelpers.makeContext(localSettingsExists: true)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         let localFinding = findings.first { $0.title.contains("Local settings") }
         #expect(localFinding != nil)
@@ -357,7 +357,7 @@ struct GoodPracticesCheckTests {
     @Test("Reports good practice for project MCP")
     func reportsProjectMCP() {
         let context = HealthCheckTestHelpers.makeContext(mcpConfigExists: true)
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         let mcpFinding = findings.first { $0.title.contains("Project-scoped MCP") }
         #expect(mcpFinding != nil)
@@ -367,13 +367,13 @@ struct GoodPracticesCheckTests {
     @Test("No good practices for empty config")
     func noGoodPracticesEmpty() {
         let context = HealthCheckTestHelpers.makeContext()
-        let findings = check.check(context: context)
+        let findings = self.check.check(context: context)
 
         #expect(findings.isEmpty)
     }
 }
 
-// MARK: - Well-Configured Project Tests
+// MARK: - WellConfiguredProjectTests
 
 @Suite("Well-Configured Project Tests")
 struct WellConfiguredProjectTests {

--- a/Fig/Tests/MCPPasteViewModelTests.swift
+++ b/Fig/Tests/MCPPasteViewModelTests.swift
@@ -102,5 +102,22 @@ struct MCPPasteViewModelTests {
         let vm = MCPPasteViewModel()
         #expect(vm.conflictStrategy == .rename)
     }
-}
 
+    @Test("conforms to Identifiable")
+    func identifiable() {
+        let vm1 = MCPPasteViewModel()
+        let vm2 = MCPPasteViewModel()
+
+        #expect(vm1.id != vm2.id)
+        #expect(vm1.id == vm1.id)
+    }
+
+    @Test("setting to nil clears view model for sheet dismissal")
+    func nilableForSheetBinding() {
+        var vm: MCPPasteViewModel? = MCPPasteViewModel(currentProject: .global)
+        #expect(vm != nil)
+
+        vm = nil
+        #expect(vm == nil)
+    }
+}

--- a/Fig/Tests/MCPPasteViewModelTests.swift
+++ b/Fig/Tests/MCPPasteViewModelTests.swift
@@ -1,0 +1,106 @@
+@testable import Fig
+import Foundation
+import Testing
+
+// MARK: - MCPPasteViewModelTests
+
+@Suite("MCP Paste ViewModel Tests")
+@MainActor
+struct MCPPasteViewModelTests {
+    @Test("Initial state is empty")
+    func initialState() {
+        let vm = MCPPasteViewModel()
+        #expect(vm.jsonText.isEmpty)
+        #expect(vm.parsedServers == nil)
+        #expect(vm.parseError == nil)
+        #expect(vm.serverCount == 0)
+        #expect(vm.canImport == false)
+        #expect(vm.importSucceeded == false)
+    }
+
+    @Test("canImport requires parsed servers and destination")
+    func canImportRequirements() {
+        let vm = MCPPasteViewModel(
+            currentProject: .project(path: "/tmp", name: "test")
+        )
+
+        // No servers parsed yet
+        #expect(vm.canImport == false)
+    }
+
+    @Test("loadDestinations populates available destinations")
+    func loadDestinations() {
+        let vm = MCPPasteViewModel()
+
+        let projects = [
+            ProjectEntry(path: "/path/to/project-a"),
+            ProjectEntry(path: "/path/to/project-b"),
+        ]
+
+        vm.loadDestinations(projects: projects)
+
+        // Should have global + 2 projects
+        #expect(vm.availableDestinations.count == 3)
+        #expect(vm.availableDestinations[0] == .global)
+    }
+
+    @Test("loadDestinations filters out projects without paths")
+    func loadDestinationsFiltersInvalid() {
+        let vm = MCPPasteViewModel()
+
+        let projects = [
+            ProjectEntry(path: "/path/to/valid"),
+            ProjectEntry(path: nil),
+        ]
+
+        vm.loadDestinations(projects: projects)
+
+        // Should have global + 1 valid project
+        #expect(vm.availableDestinations.count == 2)
+    }
+
+    @Test("selectedDestination defaults to current project")
+    func defaultDestination() {
+        let project = CopyDestination.project(path: "/tmp", name: "test")
+        let vm = MCPPasteViewModel(currentProject: project)
+
+        #expect(vm.selectedDestination == project)
+    }
+
+    @Test("selectedDestination defaults to nil when no project")
+    func defaultDestinationNil() {
+        let vm = MCPPasteViewModel()
+        #expect(vm.selectedDestination == nil)
+    }
+
+    @Test("serverNames returns sorted names")
+    func serverNamesSorted() async throws {
+        let vm = MCPPasteViewModel()
+        vm.jsonText = """
+        {
+            "mcpServers": {
+                "zebra": { "command": "z" },
+                "alpha": { "command": "a" }
+            }
+        }
+        """
+
+        // Allow async parsing to complete
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(vm.serverNames == ["alpha", "zebra"])
+    }
+
+    @Test("importSucceeded reflects result")
+    func importSucceeded() {
+        let vm = MCPPasteViewModel()
+        #expect(vm.importSucceeded == false)
+    }
+
+    @Test("conflictStrategy defaults to rename")
+    func conflictStrategyDefault() {
+        let vm = MCPPasteViewModel()
+        #expect(vm.conflictStrategy == .rename)
+    }
+}
+

--- a/Fig/Tests/MCPSharingServiceTests.swift
+++ b/Fig/Tests/MCPSharingServiceTests.swift
@@ -1,0 +1,362 @@
+@testable import Fig
+import Foundation
+import Testing
+
+// MARK: - MCPSharingServiceTests
+
+@Suite("MCP Sharing Service Tests")
+struct MCPSharingServiceTests {
+    let service = MCPSharingService.shared
+
+    // MARK: - Serialization Tests
+
+    @Test("Serializes servers to MCPConfig JSON format")
+    func serializeToJSON() async throws {
+        let servers: [String: MCPServer] = [
+            "github": .stdio(command: "npx", args: ["-y", "@mcp/server-github"]),
+            "api": .http(url: "https://mcp.example.com"),
+        ]
+
+        let json = try service.serializeToJSON(servers: servers)
+
+        // Verify it's valid MCPConfig format
+        let data = try #require(json.data(using: .utf8))
+        let config = try JSONDecoder().decode(MCPConfig.self, from: data)
+        #expect(config.mcpServers?.count == 2)
+        #expect(config.mcpServers?["github"]?.command == "npx")
+        #expect(config.mcpServers?["api"]?.url == "https://mcp.example.com")
+    }
+
+    @Test("Serialized JSON round-trips correctly")
+    func serializationRoundTrip() async throws {
+        let servers: [String: MCPServer] = [
+            "github": .stdio(
+                command: "npx",
+                args: ["-y", "@mcp/server-github"],
+                env: ["GITHUB_TOKEN": "tok-123"]
+            ),
+            "slack": .stdio(command: "npx", args: ["-y", "@mcp/server-slack"]),
+        ]
+
+        let json = try service.serializeToJSON(servers: servers)
+        let parsed = try await service.parseServersFromJSON(json)
+
+        #expect(parsed.count == 2)
+        #expect(parsed["github"]?.command == "npx")
+        #expect(parsed["github"]?.env?["GITHUB_TOKEN"] == "tok-123")
+        #expect(parsed["slack"]?.command == "npx")
+    }
+
+    @Test("Serializes empty server dictionary")
+    func serializeEmpty() async throws {
+        let json = try service.serializeToJSON(servers: [:])
+        let data = try #require(json.data(using: .utf8))
+        let config = try JSONDecoder().decode(MCPConfig.self, from: data)
+        #expect(config.mcpServers?.isEmpty == true)
+    }
+
+    @Test("Serialized JSON uses sorted keys")
+    func serializeSortedKeys() async throws {
+        let servers: [String: MCPServer] = [
+            "zebra": .stdio(command: "z"),
+            "alpha": .stdio(command: "a"),
+        ]
+
+        let json = try service.serializeToJSON(servers: servers)
+
+        // "alpha" should appear before "zebra" in the output
+        let alphaRange = try #require(json.range(of: "alpha"))
+        let zebraRange = try #require(json.range(of: "zebra"))
+        #expect(alphaRange.lowerBound < zebraRange.lowerBound)
+    }
+
+    // MARK: - Redaction Tests
+
+    @Test("Redaction replaces sensitive env values with placeholders")
+    func redactSensitiveEnv() async throws {
+        let servers: [String: MCPServer] = [
+            "github": .stdio(
+                command: "npx",
+                args: ["-y", "@mcp/server-github"],
+                env: [
+                    "GITHUB_TOKEN": "ghp_secret123",
+                    "PATH": "/usr/local/bin",
+                ]
+            ),
+        ]
+
+        let json = try service.serializeToJSON(servers: servers, redactSensitive: true)
+        let parsed = try await service.parseServersFromJSON(json)
+
+        #expect(parsed["github"]?.env?["GITHUB_TOKEN"] == "<YOUR_GITHUB_TOKEN>")
+        #expect(parsed["github"]?.env?["PATH"] == "/usr/local/bin")
+    }
+
+    @Test("Redaction replaces sensitive header values with placeholders")
+    func redactSensitiveHeaders() async throws {
+        let servers: [String: MCPServer] = [
+            "api": .http(
+                url: "https://example.com",
+                headers: [
+                    "Authorization": "Bearer secret",
+                    "Content-Type": "application/json",
+                ]
+            ),
+        ]
+
+        let json = try service.serializeToJSON(servers: servers, redactSensitive: true)
+        let parsed = try await service.parseServersFromJSON(json)
+
+        #expect(parsed["api"]?.headers?["Authorization"] == "<YOUR_AUTHORIZATION>")
+        #expect(parsed["api"]?.headers?["Content-Type"] == "application/json")
+    }
+
+    @Test("Redaction preserves non-sensitive values")
+    func redactPreservesNonSensitive() async throws {
+        let servers: [String: MCPServer] = [
+            "safe": .stdio(
+                command: "npx",
+                env: [
+                    "NODE_ENV": "production",
+                    "DEBUG": "true",
+                ]
+            ),
+        ]
+
+        let json = try service.serializeToJSON(servers: servers, redactSensitive: true)
+        let parsed = try await service.parseServersFromJSON(json)
+
+        #expect(parsed["safe"]?.env?["NODE_ENV"] == "production")
+        #expect(parsed["safe"]?.env?["DEBUG"] == "true")
+    }
+
+    @Test("Redaction without sensitive data returns same JSON")
+    func redactNoSensitiveData() async throws {
+        let servers: [String: MCPServer] = [
+            "safe": .stdio(command: "echo", env: ["PATH": "/bin"]),
+        ]
+
+        let normalJSON = try service.serializeToJSON(servers: servers, redactSensitive: false)
+        let redactedJSON = try service.serializeToJSON(servers: servers, redactSensitive: true)
+
+        #expect(normalJSON == redactedJSON)
+    }
+
+    // MARK: - Parsing Tests
+
+    @Test("Parses MCPConfig format")
+    func parseMCPConfigFormat() async throws {
+        let json = """
+        {
+            "mcpServers": {
+                "github": {
+                    "command": "npx",
+                    "args": ["-y", "@mcp/server-github"],
+                    "env": { "GITHUB_TOKEN": "tok" }
+                },
+                "api": {
+                    "type": "http",
+                    "url": "https://mcp.example.com"
+                }
+            }
+        }
+        """
+
+        let servers = try await service.parseServersFromJSON(json)
+        #expect(servers.count == 2)
+        #expect(servers["github"]?.command == "npx")
+        #expect(servers["github"]?.env?["GITHUB_TOKEN"] == "tok")
+        #expect(servers["api"]?.url == "https://mcp.example.com")
+    }
+
+    @Test("Parses flat dictionary format")
+    func parseFlatDictFormat() async throws {
+        let json = """
+        {
+            "github": {
+                "command": "npx",
+                "args": ["-y", "@mcp/server-github"]
+            },
+            "slack": {
+                "command": "npx",
+                "args": ["-y", "@mcp/server-slack"]
+            }
+        }
+        """
+
+        let servers = try await service.parseServersFromJSON(json)
+        #expect(servers.count == 2)
+        #expect(servers["github"]?.command == "npx")
+        #expect(servers["slack"]?.command == "npx")
+    }
+
+    @Test("Parses single named server")
+    func parseSingleNamed() async throws {
+        let json = """
+        {
+            "my-server": {
+                "command": "npx",
+                "args": ["-y", "some-server"]
+            }
+        }
+        """
+
+        let servers = try await service.parseServersFromJSON(json)
+        #expect(servers.count == 1)
+        #expect(servers["my-server"]?.command == "npx")
+    }
+
+    @Test("Parses single unnamed server")
+    func parseSingleUnnamed() async throws {
+        let json = """
+        {
+            "command": "npx",
+            "args": ["-y", "@mcp/server-github"]
+        }
+        """
+
+        let servers = try await service.parseServersFromJSON(json)
+        #expect(servers.count == 1)
+        #expect(servers["server"]?.command == "npx")
+    }
+
+    @Test("Parses single unnamed HTTP server")
+    func parseSingleUnnamedHTTP() async throws {
+        let json = """
+        {
+            "type": "http",
+            "url": "https://mcp.example.com"
+        }
+        """
+
+        let servers = try await service.parseServersFromJSON(json)
+        #expect(servers.count == 1)
+        #expect(servers["server"]?.url == "https://mcp.example.com")
+    }
+
+    @Test("Rejects invalid JSON")
+    func parseInvalidJSON() async {
+        do {
+            _ = try await service.parseServersFromJSON("not json at all")
+            Issue.record("Expected error for invalid JSON")
+        } catch {
+            #expect(error is MCPSharingError)
+        }
+    }
+
+    @Test("Rejects empty JSON object")
+    func parseEmptyObject() async {
+        do {
+            _ = try await service.parseServersFromJSON("{}")
+            Issue.record("Expected error for empty JSON object")
+        } catch {
+            #expect(error is MCPSharingError)
+        }
+    }
+
+    @Test("Rejects JSON array")
+    func parseArray() async {
+        do {
+            _ = try await service.parseServersFromJSON("[1, 2, 3]")
+            Issue.record("Expected error for JSON array")
+        } catch {
+            #expect(error is MCPSharingError)
+        }
+    }
+
+    // MARK: - Sensitive Data Detection Tests
+
+    @Test("Detects sensitive env vars across multiple servers")
+    func detectSensitiveMultipleServers() async {
+        let servers: [String: MCPServer] = [
+            "github": .stdio(
+                command: "npx",
+                env: ["GITHUB_TOKEN": "tok", "PATH": "/bin"]
+            ),
+            "slack": .stdio(
+                command: "npx",
+                env: ["SLACK_API_KEY": "key"]
+            ),
+        ]
+
+        let warnings = await service.detectSensitiveData(servers: servers)
+        let warningKeys = warnings.map(\.key)
+
+        #expect(warningKeys.contains("github.GITHUB_TOKEN"))
+        #expect(warningKeys.contains("slack.SLACK_API_KEY"))
+        #expect(!warningKeys.contains("github.PATH"))
+    }
+
+    @Test("Detects sensitive HTTP headers")
+    func detectSensitiveHeaders() async {
+        let servers: [String: MCPServer] = [
+            "api": .http(
+                url: "https://example.com",
+                headers: [
+                    "Authorization": "Bearer tok",
+                    "Content-Type": "application/json",
+                ]
+            ),
+        ]
+
+        let warnings = await service.detectSensitiveData(servers: servers)
+        let warningKeys = warnings.map(\.key)
+
+        #expect(warningKeys.contains("api.Authorization"))
+        #expect(!warningKeys.contains("api.Content-Type"))
+    }
+
+    @Test("Returns empty for servers without secrets")
+    func noSensitiveData() async {
+        let servers: [String: MCPServer] = [
+            "safe": .stdio(command: "echo", env: ["NODE_ENV": "prod"]),
+            "web": .http(url: "https://example.com"),
+        ]
+
+        let warnings = await service.detectSensitiveData(servers: servers)
+        #expect(warnings.isEmpty)
+    }
+
+    @Test("containsSensitiveData returns correct boolean")
+    func containsSensitiveDataBool() async {
+        let withSecrets: [String: MCPServer] = [
+            "gh": .stdio(command: "npx", env: ["GITHUB_TOKEN": "tok"]),
+        ]
+        let withoutSecrets: [String: MCPServer] = [
+            "safe": .stdio(command: "echo"),
+        ]
+
+        #expect(await service.containsSensitiveData(servers: withSecrets) == true)
+        #expect(await service.containsSensitiveData(servers: withoutSecrets) == false)
+    }
+
+    // MARK: - BulkImportResult Tests
+
+    @Test("BulkImportResult summary formatting")
+    func bulkImportResultSummary() {
+        let result = BulkImportResult(
+            imported: ["a", "b"],
+            skipped: ["c"],
+            renamed: ["d": "d-copy"],
+            errors: []
+        )
+
+        #expect(result.totalImported == 3)
+        #expect(result.summary.contains("2 imported"))
+        #expect(result.summary.contains("1 renamed"))
+        #expect(result.summary.contains("1 skipped"))
+    }
+
+    @Test("BulkImportResult empty summary")
+    func bulkImportResultEmptySummary() {
+        let result = BulkImportResult(
+            imported: [],
+            skipped: [],
+            renamed: [:],
+            errors: []
+        )
+
+        #expect(result.totalImported == 0)
+        #expect(result.summary.isEmpty)
+    }
+}

--- a/Fig/Tests/OnboardingViewModelTests.swift
+++ b/Fig/Tests/OnboardingViewModelTests.swift
@@ -122,8 +122,6 @@ struct OnboardingViewModelTests {
         }
     }
 
-    // MARK: - State Properties
-
     @Suite("State Properties")
     struct StateProperties {
         @Test("isFirstStep is true only on welcome")

--- a/Fig/Tests/ProjectExplorerViewModelTests.swift
+++ b/Fig/Tests/ProjectExplorerViewModelTests.swift
@@ -1,0 +1,289 @@
+@testable import Fig
+import Foundation
+import Testing
+
+// MARK: - ProjectExplorerViewModelTests
+
+@Suite("ProjectExplorerViewModel Tests")
+@MainActor
+struct ProjectExplorerViewModelTests {
+    // MARK: - Grouping
+
+    @Suite("Grouping by Parent Directory")
+    @MainActor
+    struct GroupingTests {
+        @Test("isGroupedByParent defaults to false")
+        func defaultsToFalse() {
+            let vm = ProjectExplorerViewModel()
+            #expect(vm.isGroupedByParent == false)
+        }
+
+        @Test("groupedProjects groups by parent directory")
+        func groupsByParent() {
+            let vm = ProjectExplorerViewModel()
+            vm.projects = [
+                ProjectEntry(path: "/Users/test/code/project-a"),
+                ProjectEntry(path: "/Users/test/code/project-b"),
+                ProjectEntry(path: "/Users/test/repos/other"),
+            ]
+
+            let groups = vm.groupedProjects
+            #expect(groups.count == 2)
+
+            let codeGroup = groups.first { $0.parentPath == "/Users/test/code" }
+            #expect(codeGroup != nil)
+            #expect(codeGroup?.projects.count == 2)
+
+            let reposGroup = groups.first { $0.parentPath == "/Users/test/repos" }
+            #expect(reposGroup != nil)
+            #expect(reposGroup?.projects.count == 1)
+        }
+
+        @Test("groupedProjects are sorted by parent path")
+        func groupsSortedByPath() {
+            let vm = ProjectExplorerViewModel()
+            vm.projects = [
+                ProjectEntry(path: "/z/project"),
+                ProjectEntry(path: "/a/project"),
+            ]
+
+            let groups = vm.groupedProjects
+            #expect(groups.count == 2)
+            #expect(groups.first?.parentPath == "/a")
+            #expect(groups.last?.parentPath == "/z")
+        }
+
+        @Test("projects within group sorted by name")
+        func projectsSortedWithinGroup() {
+            let vm = ProjectExplorerViewModel()
+            vm.projects = [
+                ProjectEntry(path: "/code/zebra"),
+                ProjectEntry(path: "/code/alpha"),
+                ProjectEntry(path: "/code/middle"),
+            ]
+
+            let groups = vm.groupedProjects
+            #expect(groups.count == 1)
+            #expect(groups.first?.projects.count == 3)
+            #expect(groups.first?.projects[0].name == "alpha")
+            #expect(groups.first?.projects[1].name == "middle")
+            #expect(groups.first?.projects[2].name == "zebra")
+        }
+
+        @Test("groupedProjects respects search filter")
+        func respectsSearchFilter() {
+            let vm = ProjectExplorerViewModel()
+            vm.projects = [
+                ProjectEntry(path: "/code/alpha"),
+                ProjectEntry(path: "/code/beta"),
+            ]
+            vm.searchQuery = "alpha"
+
+            let groups = vm.groupedProjects
+            #expect(groups.count == 1)
+            #expect(groups.first?.projects.count == 1)
+            #expect(groups.first?.projects.first?.name == "alpha")
+        }
+
+        @Test("groupedProjects returns empty when no projects")
+        func emptyWhenNoProjects() {
+            let vm = ProjectExplorerViewModel()
+            #expect(vm.groupedProjects.isEmpty)
+        }
+
+        @Test("projects without path go into Unknown group")
+        func nilPathGroup() {
+            let vm = ProjectExplorerViewModel()
+            vm.projects = [
+                ProjectEntry(path: nil),
+            ]
+
+            let groups = vm.groupedProjects
+            #expect(groups.count == 1)
+            #expect(groups.first?.parentPath == "Unknown")
+        }
+
+        @Test("multiple parent directories create separate groups")
+        func multipleParents() {
+            let vm = ProjectExplorerViewModel()
+            vm.projects = [
+                ProjectEntry(path: "/workspace/fig/doha"),
+                ProjectEntry(path: "/workspace/fig/almaty"),
+                ProjectEntry(path: "/workspace/fig/cebu"),
+                ProjectEntry(path: "/workspace/other/project"),
+                ProjectEntry(path: "/home/personal"),
+            ]
+
+            let groups = vm.groupedProjects
+            #expect(groups.count == 3)
+
+            let figGroup = groups.first { $0.parentPath == "/workspace/fig" }
+            #expect(figGroup?.projects.count == 3)
+
+            let otherGroup = groups.first { $0.parentPath == "/workspace/other" }
+            #expect(otherGroup?.projects.count == 1)
+
+            let homeGroup = groups.first { $0.parentPath == "/home" }
+            #expect(homeGroup?.projects.count == 1)
+        }
+
+        @Test("search that eliminates all projects from a group hides that group")
+        func searchHidesEmptyGroups() {
+            let vm = ProjectExplorerViewModel()
+            vm.projects = [
+                ProjectEntry(path: "/code/alpha"),
+                ProjectEntry(path: "/repos/beta"),
+            ]
+            vm.searchQuery = "alpha"
+
+            let groups = vm.groupedProjects
+            #expect(groups.count == 1)
+            #expect(groups.first?.parentPath == "/code")
+        }
+
+        @Test("group displayName abbreviates home directory")
+        func displayNameAbbreviation() {
+            let vm = ProjectExplorerViewModel()
+            let home = FileManager.default.homeDirectoryForCurrentUser.path
+            vm.projects = [
+                ProjectEntry(path: "\(home)/code/project"),
+            ]
+
+            let groups = vm.groupedProjects
+            #expect(groups.first?.displayName == "~/code")
+        }
+    }
+
+    // MARK: - Missing Projects
+
+    @Suite("Missing Projects")
+    @MainActor
+    struct MissingProjectsTests {
+        @Test("missingProjects returns projects with non-existent paths")
+        func identifiesMissing() {
+            let vm = ProjectExplorerViewModel()
+            vm.projects = [
+                ProjectEntry(path: "/nonexistent/path/12345"),
+                ProjectEntry(path: "/tmp"),
+            ]
+
+            let missing = vm.missingProjects
+            #expect(missing.count == 1)
+            #expect(missing.first?.path == "/nonexistent/path/12345")
+        }
+
+        @Test("hasMissingProjects is true when missing exist")
+        func hasMissingTrue() {
+            let vm = ProjectExplorerViewModel()
+            vm.projects = [
+                ProjectEntry(path: "/nonexistent/path/12345"),
+            ]
+            #expect(vm.hasMissingProjects == true)
+        }
+
+        @Test("hasMissingProjects is false when all exist")
+        func hasMissingFalse() {
+            let vm = ProjectExplorerViewModel()
+            vm.projects = [
+                ProjectEntry(path: "/tmp"),
+            ]
+            #expect(vm.hasMissingProjects == false)
+        }
+
+        @Test("hasMissingProjects is false when empty")
+        func hasMissingEmpty() {
+            let vm = ProjectExplorerViewModel()
+            #expect(vm.hasMissingProjects == false)
+        }
+
+        @Test("missingProjects includes nil-path projects")
+        func nilPathIsMissing() {
+            let vm = ProjectExplorerViewModel()
+            vm.projects = [
+                ProjectEntry(path: nil),
+            ]
+
+            #expect(vm.missingProjects.count == 1)
+        }
+
+        @Test("missingProjects with mix of existing and non-existing")
+        func mixedExistence() {
+            let vm = ProjectExplorerViewModel()
+            vm.projects = [
+                ProjectEntry(path: "/tmp"),
+                ProjectEntry(path: "/nonexistent/a"),
+                ProjectEntry(path: "/nonexistent/b"),
+                ProjectEntry(path: "/tmp"),
+            ]
+
+            #expect(vm.missingProjects.count == 2)
+            #expect(vm.hasMissingProjects == true)
+        }
+    }
+
+    // MARK: - Favorites Interaction
+
+    @Suite("Favorites and Recents")
+    @MainActor
+    struct FavoritesTests {
+        @Test("toggleFavorite adds and removes")
+        func toggleFavorite() {
+            let vm = ProjectExplorerViewModel()
+            let id = UUID().uuidString
+            let project = ProjectEntry(path: "/test/toggle-\(id)")
+
+            vm.toggleFavorite(project)
+            #expect(vm.isFavorite(project))
+
+            vm.toggleFavorite(project)
+            #expect(!vm.isFavorite(project))
+        }
+
+        @Test("favoriteProjects excludes projects not in favorites")
+        func favoriteProjectsFiltering() {
+            let vm = ProjectExplorerViewModel()
+            let id = UUID().uuidString
+            let fav = ProjectEntry(path: "/test/fav-filter-\(id)")
+            let regular = ProjectEntry(path: "/test/reg-filter-\(id)")
+            vm.projects = [fav, regular]
+            vm.toggleFavorite(fav)
+
+            #expect(vm.favoriteProjects.count == 1)
+            #expect(vm.favoriteProjects.first?.path == fav.path)
+        }
+
+        @Test("filteredProjects excludes favorites and recents")
+        func filteredExcludesFavorites() {
+            let vm = ProjectExplorerViewModel()
+            let id = UUID().uuidString
+            let fav = ProjectEntry(path: "/test/fav-excl-\(id)")
+            let regular = ProjectEntry(path: "/test/reg-excl-\(id)")
+            vm.projects = [fav, regular]
+            vm.toggleFavorite(fav)
+
+            #expect(vm.filteredProjects.count == 1)
+            #expect(vm.filteredProjects.first?.path == regular.path)
+        }
+    }
+
+    // MARK: - Grouped Projects and Favorites Interaction
+
+    @Suite("Grouping with Favorites")
+    @MainActor
+    struct GroupingWithFavoritesTests {
+        @Test("groupedProjects excludes favorites")
+        func excludesFavorites() {
+            let vm = ProjectExplorerViewModel()
+            let id = UUID().uuidString
+            let fav = ProjectEntry(path: "/code/fav-grp-\(id)")
+            let regular = ProjectEntry(path: "/code/reg-grp-\(id)")
+            vm.projects = [fav, regular]
+            vm.toggleFavorite(fav)
+
+            let groups = vm.groupedProjects
+            #expect(groups.count == 1)
+            #expect(groups.first?.projects.count == 1)
+            #expect(groups.first?.projects.first?.path == regular.path)
+        }
+    }
+}

--- a/Fig/Tests/ProjectGroupTests.swift
+++ b/Fig/Tests/ProjectGroupTests.swift
@@ -1,0 +1,51 @@
+@testable import Fig
+import Testing
+
+@Suite("ProjectGroup Tests")
+struct ProjectGroupTests {
+    @Test("id equals parentPath")
+    func idEqualsParentPath() {
+        let group = ProjectGroup(
+            parentPath: "/Users/test/code",
+            displayName: "~/code",
+            projects: []
+        )
+        #expect(group.id == "/Users/test/code")
+    }
+
+    @Test("stores projects correctly")
+    func storesProjects() {
+        let projects = [
+            ProjectEntry(path: "/code/alpha"),
+            ProjectEntry(path: "/code/beta"),
+        ]
+        let group = ProjectGroup(
+            parentPath: "/code",
+            displayName: "/code",
+            projects: projects
+        )
+        #expect(group.projects.count == 2)
+        #expect(group.projects[0].path == "/code/alpha")
+        #expect(group.projects[1].path == "/code/beta")
+    }
+
+    @Test("preserves displayName")
+    func preservesDisplayName() {
+        let group = ProjectGroup(
+            parentPath: "/Users/alice/code",
+            displayName: "~/code",
+            projects: []
+        )
+        #expect(group.displayName == "~/code")
+    }
+
+    @Test("empty projects list is valid")
+    func emptyProjectsList() {
+        let group = ProjectGroup(
+            parentPath: "/empty",
+            displayName: "/empty",
+            projects: []
+        )
+        #expect(group.projects.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Add clipboard-based sharing and import capabilities for MCP server configurations with sensitive data redaction support.

**Features:**
- **Copy to clipboard**: Export all MCP servers from any scope (project/global) as shareable `.mcp.json`-format JSON
- **Import from JSON**: Paste JSON to import servers with conflict resolution (rename/overwrite/skip)
- **Sensitive data handling**: Automatic redaction with `<YOUR_KEY_NAME>` placeholders (default) or raw export
- **Export .mcp.json**: Generate `.mcp.json` files directly in projects
- **Global MCP management**: Enable full CRUD + sharing for global MCP servers (previously read-only)

## Architecture

```mermaid
graph TB
    subgraph Services["Services"]
        MCPSharingService["MCPSharingService<br/>(actor)"]
    end
    
    subgraph ViewModels["ViewModels"]
        PasteVM["MCPPasteViewModel<br/>(@MainActor)"]
    end
    
    subgraph Views["Views"]
        ProjectDetail["ProjectDetailView"]
        GlobalSettings["GlobalSettingsDetailView"]
        MCPServersTab["MCPServersTabView"]
        PasteSheet["MCPPasteSheet"]
    end
    
    MCPSharingService -->|serialize/parse| PasteVM
    MCPSharingService -->|write/read| ProjectDetail
    MCPSharingService -->|write/read| GlobalSettings
    ProjectDetail -->|callbacks| MCPServersTab
    GlobalSettings -->|callbacks| MCPServersTab
    PasteVM -->|UI state| PasteSheet
```

## Test Coverage

- **MCPSharingServiceTests** (22 tests): Serialization, redaction, parsing, sensitive data detection, bulk import
- **MCPPasteViewModelTests** (7 tests): Initialization, state, destination loading, import flow
- All 172 existing tests continue to pass
- Zero build warnings, strict Swift 6 concurrency

## Implementation Details

**MCPSharingService** (actor):
- `nonisolated func serializeToJSON()` → MCPConfig JSON with optional redaction
- `func parseServersFromJSON()` → Supports MCPConfig, flat dict, single named/unnamed formats
- `@MainActor func writeToClipboard()/readFromClipboard()` → NSPasteboard operations
- `func detectSensitiveData()` → Pattern-based detection for tokens, keys, secrets, etc.
- `func importServers()` → Bulk import with conflict strategies (rename/overwrite/skip)

**UI Changes**:
- Project view: "Copy All" button + "Import from JSON" (Cmd+Shift+V) + "Export .mcp.json" menu
- Global settings: Full MCP CRUD + sharing (add/edit/delete/copy/copyAll/paste)
- Sensitive data alert: Choose redaction or raw export before copying

**Files Added** (5):
- `MCPSharingService.swift` (423 LOC) — Core service
- `MCPPasteViewModel.swift` (158 LOC) — Paste/import flow
- `MCPPasteSheet.swift` (300 LOC) — Import dialog UI
- `MCPSharingServiceTests.swift` (362 LOC)
- `MCPPasteViewModelTests.swift` (106 LOC)

**Files Modified** (5):
- `ConfigTabViews.swift` — Added `onCopyAll`/`onPasteServers` callbacks
- `ProjectDetailView.swift` — Wired sharing features, export, header menu
- `GlobalSettingsDetailView.swift` — Full MCP management
- `AppCommands.swift` — Cmd+Shift+V keyboard shortcut
- `FocusedValues.swift` — `pasteMCPServersAction` focused value

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)